### PR TITLE
Working version of screened opacity for properties

### DIFF
--- a/src/map/colorscales.ts
+++ b/src/map/colorscales.ts
@@ -3,6 +3,7 @@
  * @module map
  */
 
+import assert from 'assert';
 import { ColorScale } from './plotly/plotly-scatter';
 
 type RGBColorMap = [number, [number, number, number]][];
@@ -684,20 +685,27 @@ const BRG: RGBColorMap = [
 ];
 
 interface ColorMaps {
-    [key: string]: ColorScale;
+    [key: string]: RGBColorMap;
 }
 
 /* eslint-disable sort-keys */
 /** @hidden */
 export const COLOR_MAPS: ColorMaps = {
-    inferno: rgb_to_plotly(INFERNO),
-    magma: rgb_to_plotly(MAGMA),
-    plasma: rgb_to_plotly(PLASMA),
-    viridis: rgb_to_plotly(VIRIDIS),
-    cividis: rgb_to_plotly(CIVIDIS),
-    seismic: rgb_to_plotly(SEISMIC),
-    brg: rgb_to_plotly(BRG),
-    'twilight (periodic)': rgb_to_plotly(TWILIGHT),
-    'twilight dark (periodic)': rgb_to_plotly(TWILIGHT_SHIFTED),
-    'hsv (periodic)': rgb_to_plotly(HSV),
+    inferno: INFERNO,
+    magma: MAGMA,
+    plasma: PLASMA,
+    viridis: VIRIDIS,
+    cividis: CIVIDIS,
+    seismic: SEISMIC,
+    brg: BRG,
+    'twilight (periodic)': TWILIGHT,
+    'twilight dark (periodic)': TWILIGHT_SHIFTED,
+    'hsv (periodic)': HSV,
 };
+
+export function getColorMap(colormap: string): ColorScale {
+    const cmap = COLOR_MAPS[colormap];
+    assert(cmap !== undefined);
+
+    return rgb_to_plotly(cmap);
+}

--- a/src/map/data.ts
+++ b/src/map/data.ts
@@ -5,6 +5,7 @@
 
 import { Property } from '../dataset';
 import { sendWarning } from '../utils';
+import { DisplayMode } from '../indexer';
 
 /** @hidden
  * Properties turned into numeric values to be displayed on the map.
@@ -155,5 +156,9 @@ export class MapData {
         // sanity checks
         checkSize('structure', this.structure);
         checkSize('atom', this.atom);
+    }
+
+    public length(mode: DisplayMode): number {
+        return this[mode][Object.keys(this[mode])[0]].values.length;
     }
 }

--- a/src/map/options.html
+++ b/src/map/options.html
@@ -191,10 +191,64 @@
 
                     <div class="input-group input-group-sm">
                         <div class="input-group-prepend">
-                            <label class="input-group-text" for="chsp-size">size:</label>
+                            <label class="input-group-text" for="chsp-opacity-mode">opacity:</label>
                         </div>
-                        <select id="chsp-size" class="custom-select">
-                            <option value="">fixed</option>
+                        <select id="chsp-opacity-mode" class="custom-select" enabled>
+                            <option value="constant">constant</option>
+                            <option value="filter">filter</option>
+                        </select>
+                    </div>
+
+                    <button
+                        class="btn btn-sm btn-secondary chsp-extra-options-btn"
+                        type="button"
+                        data-toggle="collapse"
+                        data-target="#chsp-extra-opacity"
+                        id="chsp-opacity-more"
+                    >
+                        more options
+                    </button>
+
+                    <div class="collapse chsp-map-extra-options" id="chsp-extra-opacity">
+                        <div class="input-group input-group-sm">
+                            <div class="input-group-prepend">
+                                <label class="input-group-text" for="chsp-opacity-minimum">min:</label>
+                            </div>
+                            <input id="chsp-opacity-minimum" min="0" max="1" step="0.05" class="form-control custom-range" type="number" step="any" />
+                        </div>
+
+                        <div class="input-group input-group-sm">
+                            <div class="input-group-prepend">
+                                <label class="input-group-text" for="chsp-opacity-maximum">max:</label>
+                            </div>
+                            <input id="chsp-opacity-maximum" min="0" max="1" step="0.05" class="form-control custom-range" type="number" step="any" />
+                        </div>
+                        <div class="custom-switch">
+                            <input class="custom-control-input" id="chsp-opacity-greyed" type="checkbox" disabled checked />
+                            <label class="custom-control-label" for="chsp-opacity-greyed" title="grey-translucent">Color Background Points?</label>
+                        </div>
+                        <div class="input-group input-group-sm">
+                            <div class="input-group-prepend">
+                                <label class="input-group-text" for="chsp-opacity-property">property:</label>
+                            </div>
+                            <select id="chsp-opacity-property" class="custom-select" disabled></select>
+                        </div>
+                        <div class="input-group input-group-sm">
+                            <select id="chsp-opacity-operator" class="custom-select" disabled>
+                                <option value="<">&lt</option>
+                                <option value=">">&gt</option>
+                                <option value="=">=</option>
+                            </select>
+                            <input id="chsp-opacity-cutoff" class="form-control" type="number" step="any" />
+                        </div>
+                    </div>
+
+                    <div class="input-group input-group-sm">
+                        <div class="input-group-prepend">
+                            <label class="input-group-text" for="chsp-size-mode">size scale:</label>
+                        </div>
+                        <select id="chsp-size" class="custom-select" enabled>
+                            <option value="fixed">fixed</option>
                         </select>
                     </div>
 


### PR DESCRIPTION
This is a resurrection of #81, which addresses #79, ascribing selective opacity to points in the main trace. I've opened a new pull request because I've taken a different approach than in #81.

Here is the reasoning behind the design choices:
1. We would like to keep all of the main points in a single trace to make them clickable/discoverable.
2. Plotly does not allow varying opacity in a single trace. Therefore, in order to vary opacity in a single trace, we must convert the colormap to an RGBA (vs RGB).
3. The way I've done (2) is by stacking a bunch of RGBA colormaps of discrete opacities on top of each other (see screenshot). Because of this, I've separated the coloraxis for the colorbar, so it only appears with the full-opacity colormap.

User Functionality Questions:
What types of selective opacities do we envision? Here are some I anticipate:
1. Only highlight a structure / environment / all structures in the widget (trivial)
2. Scale the opacity with some property (trivial)
3. Render invisible any point which doesn't have the property solicited by x, y, z, or color (trivial)

Thoughts? Any other use cases we should anticipate