### PR TITLE
2D line and 3D scatter plots support in info bar

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -241,7 +241,12 @@ class DefaultVisualizer {
         };
 
         // information table & slider setup
-        this.info = new EnvironmentInfo(config.info, dataset.properties, this._indexer);
+        this.info = new EnvironmentInfo(
+            config.info,
+            dataset.properties,
+            this._indexer,
+            dataset.parameters
+        );
         this.info.onchange = (indexes) => {
             this.map.select(indexes);
             this.structure.show(indexes);

--- a/src/info/plotting.ts
+++ b/src/info/plotting.ts
@@ -1,0 +1,74 @@
+import Plotly from '../map/plotly/plotly-scatter';
+
+import { Data } from '../map/plotly/plotly-scatter';
+
+/**
+ * wrapper around scatter plots of Plotly.js for 2D properties
+ */
+export function plotMultidimProperties(
+    x: number[],
+    y: number[],
+    myDiv: HTMLElement,
+    plotWidth: number,
+    isStatic: boolean,
+    xlabel?: string,
+    ylabel?: string
+): void {
+    const trace = {
+        x: x,
+        y: y,
+        type: 'scatter',
+        mode: 'lines',
+    };
+
+    const layout = {
+        xref: 'paper',
+        yref: 'paper',
+        xaxis: {
+            title: xlabel,
+            titlefont: {
+                size: 12,
+            },
+            showgrid: false,
+            zeroline: true,
+            showline: true,
+            nticks: 5,
+        },
+        yaxis: {
+            title: ylabel,
+            titlefont: {
+                size: 12,
+            },
+            showgrid: false,
+            showline: true,
+            zeroline: false,
+            nticks: 4,
+        },
+        showlegend: false,
+        x: 0.2,
+        legend: {
+            y: 0.5,
+        },
+        autosize: true,
+        margin: {
+            l: plotWidth / 6.0,
+            r: 0,
+            b: plotWidth / 6.0,
+            t: 0,
+            pad: 0,
+        },
+        width: plotWidth,
+        height: plotWidth / 1.35, // hardcoded ratio. TODO: to be changed
+        tracetoggle: false,
+    };
+
+    const config = {
+        displayModeBar: false,
+        responsive: true,
+        staticPlot: isStatic,
+    };
+
+    const data = [trace] as Data[];
+
+    void Plotly.newPlot(myDiv, data, layout, config);
+}

--- a/src/map/data.ts
+++ b/src/map/data.ts
@@ -87,7 +87,7 @@ function propertyToNumeric(name: string, property: Property): NumericProperty {
             units: property.units,
         };
     } else {
-        throw Error(`unexpected property type '${prop_type}'`);
+        throw Error(`unexpected property type '${prop_type}'`); // error thorwn even for 2D properties
     }
 }
 


### PR DESCRIPTION
Fix #78 

For now, it is possible to visualize 1D properties as line plots (e.g. DOS plots or SOAP vectors) and 3D scatter plots in the table cells in the info bar for structures and environments. The data should be provided as [[x], [y], [z]] for every environment/structure. The z-axis is optional.

The current visualization setup is not optimal because the info bar covers entirely the structure viewer for smaller screens. I am hesitant to use bootstrap modals and have a floating window or create an extra column in the chemiscope viewer between the map and the structure viewer.

Checks for input data are not implemented (yet).
