### PR TITLE
Update to Bootstrap 5

### DIFF
--- a/app/3dmol-example.html
+++ b/app/3dmol-example.html
@@ -19,13 +19,12 @@
         <!-- bootstrap -->
         <link
             rel="stylesheet"
-            href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.4.1/css/bootstrap.min.css"
-            integrity="sha256-L/W5Wfqfa0sdBNIKN9cG6QA5F2qx4qICmU2VgLruv9Y="
-            crossorigin="anonymous"
-        />
+            href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css"
+            integrity="sha384-1BmE4kWBq78iYhFldvKuhfTAU6auU8tT94WrHftjDbrCEXSU1oBoqyl2QvZ6jIW3"
+            crossorigin="anonymous">
         <script
-            src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.4.1/js/bootstrap.min.js"
-            integrity="sha256-WqU1JavFxSAMcLP2WIOI+GB2zWmShMI82mTpLDcqFUg="
+            src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js"
+            integrity="sha384-ka7Sk0Gln4gmtz2MlQnikT1wXgYsOg+OMhuP+IlRH9sENBO0LRn5q+8nbTov4+1p"
             crossorigin="anonymous"
         ></script>
 

--- a/app/app.css
+++ b/app/app.css
@@ -115,6 +115,7 @@ main .ratio > * {
 
 #chemiscope-meta {
     width: max-content;
+    height: max-content;
     position: absolute;
     top: 0;
     left: 2em;

--- a/app/app.css
+++ b/app/app.css
@@ -18,6 +18,10 @@ body {
     font-size: 0.8rem;
 }
 
+.footer .container {
+    max-width: 1140px;
+}
+
 .footer a {
     color: inherit;
     text-decoration: underline;
@@ -30,6 +34,7 @@ header {
 }
 
 .navbar {
+    max-width: 1140px;
     margin-bottom: 1em;
     z-index: 999;
     background-color: inherit;
@@ -68,25 +73,29 @@ main.container-fluid {
     }
 }
 
-main .embed-responsive {
+main .ratio {
     margin: auto;
 }
 
-main .embed-responsive-item {
+main .ratio > * {
     display: flex;
     flex-flow: column;
 }
 
-.embed-responsive-5by7::before {
+.ratio-5x7 {
+    overflow-y: hidden;
+}
+
+.ratio-5x7::before {
     padding-top: 140%;
 }
 
 @media screen and (min-width: 768px) {
-    .embed-responsive-5by7 {
+    .ratio-5x7 {
         max-height: calc(100vh - 4em - 120px);
     }
 
-    main .embed-responsive {
+    main .ratio {
         /* set the width to fit the vertical space, and the height will be set automatically */
         max-width: calc(100vh - 4em - 120px);
     }
@@ -105,6 +114,7 @@ main .embed-responsive-item {
 }
 
 #chemiscope-meta {
+    width: max-content;
     position: absolute;
     top: 0;
     left: 2em;

--- a/app/app.ts
+++ b/app/app.ts
@@ -48,15 +48,15 @@ export class ChemiscopeApp {
         root.innerHTML = `<div class="container-fluid">
             <div class="row">
                 <div class="col-md-7" style="padding: 0">
-                    <div class="embed-responsive embed-responsive-1by1">
+                    <div class="ratio ratio-1x1">
                         <div id="chemiscope-meta"></div>
-                        <div id="chemiscope-map" class="embed-responsive-item" style="position: absolute"></div>
+                        <div id="chemiscope-map" style="position: absolute"></div>
                     </div>
                 </div>
 
                 <div class="col-md-5" style="padding: 0">
-                    <div class="embed-responsive embed-responsive-5by7">
-                        <div class="embed-responsive-item">
+                    <div class="ratio ratio-5x7">
+                        <div>
                             <!-- height: 0 below is a hack to force safari to
                             respect height: 100% on the children
                             https://github.com/philipwalton/flexbugs/issues/197#issuecomment-378908438

--- a/app/index.html
+++ b/app/index.html
@@ -20,11 +20,6 @@
             integrity="sha256-CSXorXvZcTkaix6Yvo6HppcZGetbYMGWSFlBw8HfCJo="
             crossorigin="anonymous"
         ></script>
-        <script
-            src="https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.12.1/jquery-ui.min.js"
-            integrity="sha256-KM512VNnjElC30ehFwehXjx1YCHPiQkOPmqnrWtpccM="
-            crossorigin="anonymous"
-        ></script>
 
         <!-- font-awesome -->
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.11.2/css/all.min.css" />
@@ -79,9 +74,13 @@
                                     <span class="dropdown-item clickable" onclick="CHEMISCOPE_APP.loadExample('Arginine-Dipeptide');">
                                         Arginine-Dipeptide
                                     </span>
-                                    <span class="dropdown-item clickable" onclick="CHEMISCOPE_APP.loadExample('CSD-1000R');"> Chemical Shieldings </span>
+                                    <span class="dropdown-item clickable" onclick="CHEMISCOPE_APP.loadExample('CSD-1000R');">
+                                        Chemical Shieldings
+                                    </span>
                                     <span class="dropdown-item clickable" onclick="CHEMISCOPE_APP.loadExample('Qm7b');"> Qm7b </span>
-                                    <span class="dropdown-item clickable" onclick="CHEMISCOPE_APP.loadExample('Azaphenacenes');"> Azaphenacenes </span>
+                                    <span class="dropdown-item clickable" onclick="CHEMISCOPE_APP.loadExample('Azaphenacenes');">
+                                        Azaphenacenes
+                                    </span>
                                     <span class="dropdown-item clickable" onclick="CHEMISCOPE_APP.loadExample('Zeolites');"> Zeolites </span>
                                 </div>
                             </li>
@@ -97,7 +96,12 @@
 
         <div class="container">
             <div class="alert alert-dismissible alert-danger pop-on-top" role="alert" id="error-display" style="display: none">
-                <button type="button" class="btn-close" aria-label="Close" onclick="document.getElementById('error-display').style.display = 'none';"></button>
+                <button
+                    type="button"
+                    class="btn-close"
+                    aria-label="Close"
+                    onclick="document.getElementById('error-display').style.display = 'none';"
+                ></button>
                 <p></p>
                 <details>
                     <summary>Backtrace</summary>
@@ -107,7 +111,12 @@
 
             <div class="alert alert-warning alert-dismissible pop-on-top" role="alert" id="warning-display" style="display: none">
                 <p></p>
-                <button type="button" class="btn-close" aria-label="Close" onclick="document.getElementById('warning-display').style.display = 'none';"></button>
+                <button
+                    type="button"
+                    class="btn-close"
+                    aria-label="Close"
+                    onclick="document.getElementById('warning-display').style.display = 'none';"
+                ></button>
             </div>
             <div style="padding: 0.5rem 1.25rem">&nbsp;</div>
 

--- a/app/index.html
+++ b/app/index.html
@@ -35,69 +35,69 @@
     <body>
         <header>
             <nav class="container navbar navbar-expand-lg navbar-dark">
-                <a class="navbar-brand" href="#">chemiscope</a>
-                <button
-                    class="navbar-toggler"
-                    type="button"
-                    data-toggle="collapse"
-                    data-target="#navbar"
-                    aria-controls="navbar"
-                    aria-expanded="false"
-                    aria-label="Toggle navigation"
-                >
-                    <span class="navbar-toggler-icon"></span>
-                </button>
+                <div class="container-fluid">
+                    <a class="navbar-brand" href="#">chemiscope</a>
+                    <button
+                        class="navbar-toggler"
+                        type="button"
+                        data-bs-toggle="collapse"
+                        data-bs-target="#navbar"
+                        aria-controls="navbar"
+                        aria-expanded="false"
+                        aria-label="Toggle navigation"
+                    >
+                        <span class="navbar-toggler-icon"></span>
+                    </button>
 
-                <div class="collapse navbar-collapse" id="navbar">
-                    <ul class="navbar-nav mr-auto">
-                        <li class="nav-item">
-                            <a class="nav-link" href="https://chemiscope.org/docs/"><i class="fa fa-book"></i> Documentation</a>
-                        </li>
+                    <div class="collapse navbar-collapse" id="navbar">
+                        <ul class="navbar-nav mr-auto">
+                            <li class="nav-item">
+                                <a class="nav-link" href="https://chemiscope.org/docs/"><i class="fa fa-book"></i> Documentation</a>
+                            </li>
 
-                        <li class="nav-item">
-                            <a class="nav-link" data-toggle="modal" href="#about"><i class="fa fa-user"></i> About</a>
-                        </li>
+                            <li class="nav-item">
+                                <a class="nav-link" data-bs-toggle="modal" href="#about"><i class="fa fa-user"></i> About</a>
+                            </li>
 
-                        <li class="nav-item hide-if-standalone">
-                            <a class="nav-link" data-toggle="modal" href="#sources"><i class="fa fa-download"></i> Sources</a>
-                        </li>
+                            <li class="nav-item hide-if-standalone">
+                                <a class="nav-link" data-bs-toggle="modal" href="#sources"><i class="fa fa-download"></i> Sources</a>
+                            </li>
 
-                        <li class="nav-item dropdown hide-if-standalone">
-                            <a
-                                class="nav-link"
-                                href="#"
-                                id="examples"
-                                role="button"
-                                data-toggle="dropdown"
-                                aria-haspopup="true"
-                                aria-expanded="false"
-                            >
-                                <i class="fa fa-images"></i> Examples
-                            </a>
-                            <div class="dropdown-menu" aria-labelledby="examples">
-                                <span class="dropdown-item clickable" onclick="CHEMISCOPE_APP.loadExample('Arginine-Dipeptide');">
-                                    Arginine-Dipeptide
-                                </span>
-                                <span class="dropdown-item clickable" onclick="CHEMISCOPE_APP.loadExample('CSD-1000R');"> Chemical Shieldings </span>
-                                <span class="dropdown-item clickable" onclick="CHEMISCOPE_APP.loadExample('Qm7b');"> Qm7b </span>
-                                <span class="dropdown-item clickable" onclick="CHEMISCOPE_APP.loadExample('Azaphenacenes');"> Azaphenacenes </span>
-                                <span class="dropdown-item clickable" onclick="CHEMISCOPE_APP.loadExample('Zeolites');"> Zeolites </span>
-                            </div>
-                        </li>
+                            <li class="nav-item dropdown hide-if-standalone">
+                                <a
+                                    class="nav-link"
+                                    href="#"
+                                    id="examples"
+                                    role="button"
+                                    data-bs-toggle="dropdown"
+                                    aria-haspopup="true"
+                                    aria-expanded="false"
+                                >
+                                    <i class="fa fa-images"></i> Examples
+                                </a>
+                                <div class="dropdown-menu" aria-labelledby="examples">
+                                    <span class="dropdown-item clickable" onclick="CHEMISCOPE_APP.loadExample('Arginine-Dipeptide');">
+                                        Arginine-Dipeptide
+                                    </span>
+                                    <span class="dropdown-item clickable" onclick="CHEMISCOPE_APP.loadExample('CSD-1000R');"> Chemical Shieldings </span>
+                                    <span class="dropdown-item clickable" onclick="CHEMISCOPE_APP.loadExample('Qm7b');"> Qm7b </span>
+                                    <span class="dropdown-item clickable" onclick="CHEMISCOPE_APP.loadExample('Azaphenacenes');"> Azaphenacenes </span>
+                                    <span class="dropdown-item clickable" onclick="CHEMISCOPE_APP.loadExample('Zeolites');"> Zeolites </span>
+                                </div>
+                            </li>
 
-                        <li>
-                            <a class="nav-link" data-toggle="modal" href="#load-save"> <i class="fa fa-file"></i> Load/Save </a>
-                        </li>
-                    </ul>
+                            <li>
+                                <a class="nav-link" data-bs-toggle="modal" href="#load-save"> <i class="fa fa-file"></i> Load/Save </a>
+                            </li>
+                        </ul>
+                    </div>
                 </div>
             </nav>
         </header>
 
         <div class="container">
-            <div class="alert alert-danger pop-on-top" role="alert" id="error-display" style="display: none">
-                <button type="button" class="close" onclick="document.getElementById('error-display').style.display = 'none';">
-                    <span aria-hidden="true">&times;</span>
-                </button>
+            <div class="alert alert-dismissible alert-danger pop-on-top" role="alert" id="error-display" style="display: none">
+                <button type="button" class="btn-close" aria-label="Close" onclick="document.getElementById('error-display').style.display = 'none';"></button>
                 <p></p>
                 <details>
                     <summary>Backtrace</summary>
@@ -105,11 +105,9 @@
                 </details>
             </div>
 
-            <div class="alert alert-warning pop-on-top" role="alert" id="warning-display" style="display: none">
-                <button type="button" class="close" onclick="document.getElementById('warning-display').style.display = 'none';">
-                    <span aria-hidden="true">&times;</span>
-                </button>
+            <div class="alert alert-warning alert-dismissible pop-on-top" role="alert" id="warning-display" style="display: none">
                 <p></p>
+                <button type="button" class="btn-close" aria-label="Close" onclick="document.getElementById('warning-display').style.display = 'none';"></button>
             </div>
             <div style="padding: 0.5rem 1.25rem">&nbsp;</div>
 
@@ -137,9 +135,7 @@
                 <div class="modal-content">
                     <div class="modal-header">
                         <h5 class="modal-title">Chemiscope: interactive structure/property explorer for materials and molecules</h5>
-                        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-                            <span aria-hidden="true">&times;</span>
-                        </button>
+                        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                     </div>
                     <div class="modal-body">
                         <p>
@@ -175,9 +171,7 @@
                 <div class="modal-content">
                     <div class="modal-header">
                         <h5 class="modal-title">Download chemiscope</h5>
-                        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-                            <span aria-hidden="true">&times;</span>
-                        </button>
+                        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                     </div>
                     <div class="modal-body">
                         <p>
@@ -205,9 +199,7 @@
                 <div class="modal-content">
                     <div class="modal-header">
                         <h5 class="modal-title">Load and save data</h5>
-                        <button type="button" class="close" data-dismiss="modal" aria-label="Close" id="close-load-save-modal">
-                            <span aria-hidden="true">&times;</span>
-                        </button>
+                        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close" id="close-load-save-modal"></button>
                     </div>
 
                     <div class="modal-body">
@@ -223,43 +215,37 @@
                                 pick a file
                                 <input id="load-dataset" type="file" accept=".json,.gz" class="hidden-input-file" />
                             </label>
-                            <div class="input-group-append">
-                                <button
-                                    class="btn btn-primary width-10em"
-                                    type="button"
-                                    name="button"
-                                    onclick="document.getElementById('load-dataset').click()"
-                                >
-                                    <i class="fa fa-upload"></i> load dataset
-                                </button>
-                            </div>
+                            <button
+                                class="btn btn-primary width-10em"
+                                type="button"
+                                name="button"
+                                onclick="document.getElementById('load-dataset').click()"
+                            >
+                                <i class="fa fa-upload"></i> load dataset
+                            </button>
                         </div>
 
                         <div class="input-group" style="margin-top: 1em">
-                            <div class="input-group-prepend">
-                                <span class="input-group-text">save as</span>
-                            </div>
+                            <span class="input-group-text">save as</span>
                             <input id="save-dataset-name" class="form-control" type="text" value="dataset.json" autocomplete="off" />
-                            <div class="input-group-append">
-                                <button
-                                    class="btn btn-outline-secondary btn-outline-secondary-less-hover width-10em"
-                                    type="button"
-                                    name="button"
-                                    id="save-dataset"
-                                >
-                                    <i class="fa fa-download"></i> save dataset
-                                </button>
-                            </div>
+                            <button
+                                class="btn btn-outline-secondary btn-outline-secondary-less-hover width-10em"
+                                type="button"
+                                name="button"
+                                id="save-dataset"
+                            >
+                                <i class="fa fa-download"></i> save dataset
+                            </button>
                         </div>
 
                         <div class="grid-1-1" style="margin-top: 1em">
-                            <div class="custom-control custom-switch">
-                                <input class="custom-control-input" id="save-dataset-settings" type="checkbox" checked />
-                                <label class="custom-control-label" for="save-dataset-settings">include visualization state</label>
+                            <div class="form-check form-switch">
+                                <input class="form-check-input" id="save-dataset-settings" type="checkbox" checked />
+                                <label class="form-check-label" for="save-dataset-settings">include visualization state</label>
                             </div>
-                            <div class="custom-control custom-switch hide-on-demand-structures">
-                                <input class="custom-control-input" id="save-dataset-structures" type="checkbox" />
-                                <label class="custom-control-label" for="save-dataset-structures">include all structures</label>
+                            <div class="form-check form-switch hide-on-demand-structures">
+                                <input class="form-check-input" id="save-dataset-structures" type="checkbox" />
+                                <label class="form-check-label" for="save-dataset-structures">include all structures</label>
                             </div>
                         </div>
                         <div class="alert alert-warning hide-on-demand-structures" role="alert" style="margin: 0; margin-top: 1em">
@@ -273,47 +259,41 @@
                                 pick a file
                                 <input id="load-settings" type="file" accept=".json" class="hidden-input-file" />
                             </label>
-                            <div class="input-group-append">
-                                <button
-                                    class="btn btn-secondary width-10em"
-                                    type="button"
-                                    name="button"
-                                    onclick="document.getElementById('load-settings').click()"
-                                >
-                                    <i class="fa fa-upload"></i> load settings
-                                </button>
-                            </div>
+                            <button
+                                class="btn btn-secondary width-10em"
+                                type="button"
+                                name="button"
+                                onclick="document.getElementById('load-settings').click()"
+                            >
+                                <i class="fa fa-upload"></i> load settings
+                            </button>
                         </div>
 
                         <div class="input-group" style="margin-top: 1em">
-                            <div class="input-group-prepend">
-                                <span class="input-group-text">save as</span>
-                            </div>
+                            <span class="input-group-text">save as</span>
                             <input id="save-settings-name" class="form-control" type="text" value="settings.json" autocomplete="off" />
-                            <div class="input-group-append">
-                                <button
-                                    class="btn btn-outline-secondary btn-outline-secondary-less-hover width-10em"
-                                    type="button"
-                                    name="button"
-                                    id="save-settings"
-                                >
-                                    <i class="fa fa-download"></i> save settings
-                                </button>
-                            </div>
+                            <button
+                                class="btn btn-outline-secondary btn-outline-secondary-less-hover width-10em"
+                                type="button"
+                                name="button"
+                                id="save-settings"
+                            >
+                                <i class="fa fa-download"></i> save settings
+                            </button>
 
                             <div class="grid-1-1" style="margin-top: 1em">
-                                <div class="custom-control custom-switch align-middle">
-                                    <input class="custom-control-input" id="save-settings-map" type="checkbox" checked />
-                                    <label class="custom-control-label" for="save-settings-map">include map settings</label>
+                                <div class="form-check form-switch align-middle">
+                                    <input class="form-check-input" id="save-settings-map" type="checkbox" checked />
+                                    <label class="form-check-label" for="save-settings-map">include map settings</label>
                                 </div>
-                                <div class="custom-control custom-switch align-middle">
-                                    <input class="custom-control-input" id="save-settings-structure" type="checkbox" checked />
-                                    <label class="custom-control-label" for="save-settings-structure">include structure settings</label>
+                                <div class="form-check form-switch align-middle">
+                                    <input class="form-check-input" id="save-settings-structure" type="checkbox" checked />
+                                    <label class="form-check-label" for="save-settings-structure">include structure settings</label>
                                 </div>
                             </div>
-                            <div class="custom-control custom-switch">
-                                <input class="custom-control-input" id="save-settings-selected" type="checkbox" checked />
-                                <label class="custom-control-label" for="save-settings-selected">include selected environments</label>
+                            <div class="form-check form-switch">
+                                <input class="form-check-input" id="save-settings-selected" type="checkbox" checked />
+                                <label class="form-check-label" for="save-settings-selected">include selected environments</label>
                             </div>
                         </div>
                     </div>

--- a/app/visualizers-example.html
+++ b/app/visualizers-example.html
@@ -19,13 +19,12 @@
         <!-- bootstrap -->
         <link
             rel="stylesheet"
-            href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.4.1/css/bootstrap.min.css"
-            integrity="sha256-L/W5Wfqfa0sdBNIKN9cG6QA5F2qx4qICmU2VgLruv9Y="
-            crossorigin="anonymous"
-        />
+            href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css"
+            integrity="sha384-1BmE4kWBq78iYhFldvKuhfTAU6auU8tT94WrHftjDbrCEXSU1oBoqyl2QvZ6jIW3"
+            crossorigin="anonymous">
         <script
-            src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.4.1/js/bootstrap.min.js"
-            integrity="sha256-WqU1JavFxSAMcLP2WIOI+GB2zWmShMI82mTpLDcqFUg="
+            src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js"
+            integrity="sha384-ka7Sk0Gln4gmtz2MlQnikT1wXgYsOg+OMhuP+IlRH9sENBO0LRn5q+8nbTov4+1p"
             crossorigin="anonymous"
         ></script>
 
@@ -54,13 +53,13 @@
             <div class="row">
                 <div class="col" style="padding: 0">
                     <div id="chemiscope-meta"></div>
-                    <div class="embed-responsive embed-responsive-1by1">
-                        <div id="chemiscope-map" class="embed-responsive-item" style="position: absolute"></div>
+                    <div class="ratio ratio-1x1">
+                        <div id="chemiscope-map" style="position: absolute"></div>
                     </div>
                 </div>
 
                 <div class="col" style="padding: 0">
-                    <div class="embed-responsive-item">
+                    <div>
                         <div id="chemiscope-structure" style="height: 600px"></div>
                         <div id="chemiscope-info"></div>
                     </div>
@@ -70,7 +69,7 @@
         <h1 style="text-align: center; margin-bottom: 1em">StructureVisualizer example</h1>
         <main class="container-fluid">
             <div id="chemiscope-structure-meta"></div>
-            <div class="embed-responsive-item">
+            <div>
                 <div id="chemiscope-structure-structure" style="height: 600px"></div>
                 <div id="chemiscope-structure-info"></div>
             </div>
@@ -78,7 +77,7 @@
         <h1 style="text-align: center; margin-bottom: 1em">MapVisualizer example</h1>
         <main class="container-fluid">
             <div id="chemiscope-map-meta"></div>
-            <div class="embed-responsive-item">
+            <div>
                 <div id="chemiscope-map-map" style="height: 600px"></div>
                 <div id="chemiscope-map-info"></div>
             </div>

--- a/docs/src/embedded-example.html
+++ b/docs/src/embedded-example.html
@@ -12,19 +12,6 @@
             crossorigin="anonymous"
         ></script>
 
-        <!-- bootstrap -->
-        <link
-            rel="stylesheet"
-            href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.4.1/css/bootstrap.min.css"
-            integrity="sha256-L/W5Wfqfa0sdBNIKN9cG6QA5F2qx4qICmU2VgLruv9Y="
-            crossorigin="anonymous"
-        />
-        <script
-            src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.4.1/js/bootstrap.min.js"
-            integrity="sha256-WqU1JavFxSAMcLP2WIOI+GB2zWmShMI82mTpLDcqFUg="
-            crossorigin="anonymous"
-        ></script>
-
         <!-- Chemiscope code and default viewer code -->
         <script defer type="text/javascript" src="chemiscope.min.js"></script>
     </head>

--- a/docs/src/embedding.rst
+++ b/docs/src/embedding.rst
@@ -17,7 +17,7 @@ the HTML pages using it. You can serve these from your own web server, or use a
 CDN to deliver them.
 
 - `Bootstrap <https://getbootstrap.com/>`_ for HTML styling and basic UI;
-- Bootstrap and 3Dmol.js rely on the ubiquitous `JQuery <https://jquery.com/>`_
+- 3Dmol.js relies on the ubiquitous `JQuery <https://jquery.com/>`_
 
 Getting and building the code
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "BSD-3-Clause",
       "devDependencies": {
         "@jupyter-widgets/base": "^4.0.0",
+        "@popperjs/core": "^2.11.2",
         "@types/chai": "^4",
         "@types/glob": "^7",
         "@types/jquery": "^3.5",
@@ -50,7 +51,6 @@
         "node-loader": "^2",
         "pako": "^2",
         "plotly.js": "2.8.3",
-        "popper.js": "^1.16",
         "prettier": "2.5.1",
         "process": "^0.11.10",
         "rimraf": "^3",
@@ -563,7 +563,6 @@
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.2.tgz",
       "integrity": "sha512-92FRmppjjqz29VMJ2dn+xdyXZBrMlE42AV6Kq6BwjWV7CNUW1hs2FtxSNLQE+gJhaZ6AAmYuO9y8dshhcBl7vA==",
       "dev": true,
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
@@ -7713,17 +7712,6 @@
       "integrity": "sha1-tDkMLgedTCYtOyUExiiNlbp6R1g=",
       "dev": true
     },
-    "node_modules/popper.js": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1.tgz",
-      "integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ==",
-      "deprecated": "You can find the new Popper v2 at @popperjs/core, this package is dedicated to the legacy v1",
-      "dev": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/popperjs"
-      }
-    },
     "node_modules/portfinder": {
       "version": "1.0.28",
       "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.28.tgz",
@@ -11365,8 +11353,7 @@
       "version": "2.11.2",
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.2.tgz",
       "integrity": "sha512-92FRmppjjqz29VMJ2dn+xdyXZBrMlE42AV6Kq6BwjWV7CNUW1hs2FtxSNLQE+gJhaZ6AAmYuO9y8dshhcBl7vA==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "@socket.io/base64-arraybuffer": {
       "version": "1.0.2",
@@ -17057,12 +17044,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/polybooljs/-/polybooljs-1.2.0.tgz",
       "integrity": "sha1-tDkMLgedTCYtOyUExiiNlbp6R1g=",
-      "dev": true
-    },
-    "popper.js": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1.tgz",
-      "integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ==",
       "dev": true
     },
     "portfinder": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "@typescript-eslint/parser": "^5.10",
         "3dmol": "^1.7.1",
         "assert": "^2",
-        "bootstrap": "^4.6.0",
+        "bootstrap": "^5.1.3",
         "bubleify": "^2.0.0",
         "buffer": "^6",
         "chai": "^4",
@@ -556,6 +556,17 @@
         "math-log2": "^1.0.1",
         "parse-rect": "^1.2.0",
         "pick-by-alias": "^1.2.0"
+      }
+    },
+    "node_modules/@popperjs/core": {
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.2.tgz",
+      "integrity": "sha512-92FRmppjjqz29VMJ2dn+xdyXZBrMlE42AV6Kq6BwjWV7CNUW1hs2FtxSNLQE+gJhaZ6AAmYuO9y8dshhcBl7vA==",
+      "dev": true,
+      "peer": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/popperjs"
       }
     },
     "node_modules/@socket.io/base64-arraybuffer": {
@@ -1832,17 +1843,16 @@
       }
     },
     "node_modules/bootstrap": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.6.1.tgz",
-      "integrity": "sha512-0dj+VgI9Ecom+rvvpNZ4MUZJz8dcX7WCX+eTID9+/8HgOkv3dsRzi8BGeZJCQU6flWQVYxwTQnEZFrmJSEO7og==",
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.1.3.tgz",
+      "integrity": "sha512-fcQztozJ8jToQWXxVuEyXWW+dSo8AiXWKwiSSrKWsRB/Qt+Ewwza+JWoLKiTuQLaEPhdNAJ7+Dosc9DOIqNy7Q==",
       "dev": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/bootstrap"
       },
       "peerDependencies": {
-        "jquery": "1.9.1 - 3",
-        "popper.js": "^1.16.1"
+        "@popperjs/core": "^2.10.2"
       }
     },
     "node_modules/brace-expansion": {
@@ -11351,6 +11361,13 @@
         "pick-by-alias": "^1.2.0"
       }
     },
+    "@popperjs/core": {
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.2.tgz",
+      "integrity": "sha512-92FRmppjjqz29VMJ2dn+xdyXZBrMlE42AV6Kq6BwjWV7CNUW1hs2FtxSNLQE+gJhaZ6AAmYuO9y8dshhcBl7vA==",
+      "dev": true,
+      "peer": true
+    },
     "@socket.io/base64-arraybuffer": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@socket.io/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
@@ -12410,9 +12427,9 @@
       }
     },
     "bootstrap": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.6.1.tgz",
-      "integrity": "sha512-0dj+VgI9Ecom+rvvpNZ4MUZJz8dcX7WCX+eTID9+/8HgOkv3dsRzi8BGeZJCQU6flWQVYxwTQnEZFrmJSEO7og==",
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.1.3.tgz",
+      "integrity": "sha512-fcQztozJ8jToQWXxVuEyXWW+dSo8AiXWKwiSSrKWsRB/Qt+Ewwza+JWoLKiTuQLaEPhdNAJ7+Dosc9DOIqNy7Q==",
       "dev": true,
       "requires": {}
     },

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   },
   "devDependencies": {
     "@jupyter-widgets/base": "^4.0.0",
+    "@popperjs/core": "^2.11.2",
     "@types/chai": "^4",
     "@types/glob": "^7",
     "@types/jquery": "^3.5",
@@ -76,7 +77,6 @@
     "node-loader": "^2",
     "pako": "^2",
     "plotly.js": "2.8.3",
-    "popper.js": "^1.16",
     "prettier": "2.5.1",
     "process": "^0.11.10",
     "rimraf": "^3",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@typescript-eslint/parser": "^5.10",
     "3dmol": "^1.7.1",
     "assert": "^2",
-    "bootstrap": "^4.6.0",
+    "bootstrap": "^5.1.3",
     "bubleify": "^2.0.0",
     "buffer": "^6",
     "chai": "^4",

--- a/src/info/info.ts
+++ b/src/info/info.ts
@@ -83,8 +83,8 @@ export class EnvironmentInfo {
         if (this._indexer.mode === 'atom') {
             atomButton = `
             <div class='btn btn-sm chsp-info-atom-btn'
-                data-toggle='collapse'
-                data-target='#${atomId}'
+                data-bs-toggle='collapse'
+                data-bs-target='#${atomId}'
                 aria-expanded='false'
                 aria-controls='${atomId}'>
                 <div class="chsp-info-btns-svg">${INFO_SVG}</div>
@@ -97,8 +97,8 @@ export class EnvironmentInfo {
         <div class='accordion chsp-info-tables' id='info-tables'></div>
         <div class='chsp-info-btns'>
             <div class='btn btn-sm chsp-info-structure-btn'
-                data-toggle='collapse'
-                data-target='#${structureId}'
+                data-bs-toggle='collapse'
+                data-bs-target='#${structureId}'
                 aria-expanded='false'
                 aria-controls='${structureId}'>
                 <div class="chsp-info-btns-svg">${INFO_SVG}</div>

--- a/src/info/slider.ts
+++ b/src/info/slider.ts
@@ -33,10 +33,8 @@ export class Slider {
     constructor(root: HTMLElement, target: Target) {
         const template = document.createElement('template');
         template.innerHTML = `<div class="input-group input-group-sm">
-            <div class="input-group-prepend">
-                <span class="input-group-text"><div class="chsp-play-button"></div></span>
-            </div>
-            <input class="form-control custom-range chsp-${target}-slider" type='range' min=0 value=0 step=1></input>
+            <span class="input-group-text"><div class="chsp-play-button"></div></span>
+            <input class="form-control form-range chsp-${target}-slider" type='range' min=0 value=0 step=1 style="height: 1.9rem">
         </div>`;
         const group = template.content.firstChild as HTMLElement;
         root.appendChild(group);

--- a/src/info/table.ts
+++ b/src/info/table.ts
@@ -37,7 +37,7 @@ export class Table {
         properties: { [name: string]: Property }
     ) {
         const template = document.createElement('template');
-        template.innerHTML = `<div class="collapse chsp-info-table" id=${collapseID} data-parent='#info-tables'>
+        template.innerHTML = `<div class="collapse chsp-info-table" id=${collapseID} data-bs-parent='#info-tables'>
         <div class="chsp-properties-table">
             <table class="table table-striped table-sm">
                 <thead><th colspan=2 style="text-align: center;"></th></thead>

--- a/src/info/table.ts
+++ b/src/info/table.ts
@@ -62,15 +62,17 @@ export class Table {
             if (units !== undefined) {
                 title += `/${units}`;
             }
-            td.innerText = title;
 
             // add a tooltip containing the description of the property and underline if it exists
             const description = properties[name].description;
             if (description !== undefined) {
-                td.style.borderBottom = '1px dotted #00f';
-                td.style.cursor = 'help';
-                td.style.display = 'inline';
-                td.title = description;
+                td.innerHTML = `<span style="border-bottom: 1px dotted #00f; cursor: help"></span>`;
+
+                const span = td.firstChild as HTMLSpanElement;
+                span.innerText = title;
+                span.setAttribute('title', description);
+            } else {
+                td.innerText = title;
             }
 
             tr.appendChild(td);

--- a/src/map/options.html
+++ b/src/map/options.html
@@ -135,7 +135,7 @@
                         </button>
 
                         <div class="collapse chsp-map-extra-options" id="map-color-extra">
-                            <button class="btn btn-sm btn-light" type="button" id="map-color-reset" style="width: 100%">reset</button>
+                            <button class="btn btn-sm btn-secondary" type="button" id="map-color-reset" style="width: 100%">reset</button>
 
                             <div class="input-group input-group-sm">
                                 <label class="input-group-text" for="map-color-min">min:</label>
@@ -147,10 +147,10 @@
                                 <input id="map-color-max" class="form-control" type="number" step="any" />
                             </div>
 
-                            <div class="chsp-map-options" style="grid-column: 1 / 3">
+                            <div class="chsp-map-options" style="grid-column: auto / span 3; margin-left: -5.5em">
                                 <div class="input-group input-group-sm">
-                                    <label class="input-group-text" for="map-color-palette">palette:</label>
-                                    <select id="map-color-palette" class="form-select"></select>
+                                    <label class="input-group-text" for="map-color-palette" style="width: 6em">palette:</label>
+                                    <select id="map-color-palette" class="form-select" style="width: 13em"></select>
                                 </div>
                             </div>
                         </div>
@@ -186,8 +186,16 @@
                                 <label class="form-check-label" for="map-size-reverse" title="reverse sizes">reverse sizes</label>
                             </div>
                             <div class="input-group input-group-sm" style="grid-column: auto / span 2">
-                                <label class="input-group-text" for="map-size-factor">factor:</label>
-                                <input type="range" min="1" max="100" step="1" class="form-control form-range" id="map-size-factor" />
+                                <label class="input-group-text" for="map-size-factor" style="min-width: 6em">factor:</label>
+                                <input
+                                    type="range"
+                                    min="1"
+                                    max="100"
+                                    step="1"
+                                    class="form-control form-range"
+                                    id="map-size-factor"
+                                    style="height: 2rem"
+                                />
                             </div>
                         </div>
 

--- a/src/map/options.html
+++ b/src/map/options.html
@@ -5,100 +5,82 @@
             <div class="modal-content">
                 <div class="modal-header chsp-modal-header">
                     <h4 class="modal-title">Map settings</h4>
-                    <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                 </div>
                 <div class="modal-body">
                     <h5 class="chsp-settings-section-title">Data</h5>
                     <div class="chsp-map-options">
                         <div class="input-group input-group-sm">
-                            <div class="input-group-prepend">
-                                <label class="input-group-text" for="map-x-property">x axis:</label>
-                            </div>
-                            <select id="map-x-property" class="custom-select"></select>
+                            <label class="input-group-text" for="map-x-property">x axis:</label>
+                            <select id="map-x-property" class="form-select"></select>
                         </div>
 
                         <button
                             class="btn btn-sm btn-secondary chsp-extra-options-btn"
                             type="button"
-                            data-toggle="collapse"
-                            data-target="#map-x-extra"
+                            data-bs-toggle="collapse"
+                            data-bs-target="#map-x-extra"
                         >
                             more options
                         </button>
 
                         <div class="collapse chsp-map-extra-options" id="map-x-extra">
                             <div class="input-group input-group-sm">
-                                <div class="input-group-prepend">
-                                    <label class="input-group-text" for="map-x-scale">scale:</label>
-                                </div>
-                                <select id="map-x-scale" class="custom-select">
+                                <label class="input-group-text" for="map-x-scale">scale:</label>
+                                <select id="map-x-scale" class="form-select">
                                     <option value="linear">linear</option>
                                     <option value="log">log</option>
                                 </select>
                             </div>
 
                             <div class="input-group input-group-sm">
-                                <div class="input-group-prepend">
-                                    <label id="map-x-min-label" class="input-group-text" for="map-x-min">min:</label>
-                                </div>
+                                <label id="map-x-min-label" class="input-group-text" for="map-x-min">min:</label>
                                 <input id="map-x-min" class="form-control" type="number" step="any" />
                             </div>
 
                             <div class="input-group input-group-sm">
-                                <div class="input-group-prepend">
-                                    <label id="map-x-max-label" class="input-group-text" for="map-x-max">max:</label>
-                                </div>
+                                <label id="map-x-max-label" class="input-group-text" for="map-x-max">max:</label>
                                 <input id="map-x-max" class="form-control" type="number" step="any" />
                             </div>
                         </div>
 
                         <div class="input-group input-group-sm">
-                            <div class="input-group-prepend">
-                                <label class="input-group-text" for="map-y-property">y axis:</label>
-                            </div>
-                            <select id="map-y-property" class="custom-select"></select>
+                            <label class="input-group-text" for="map-y-property">y axis:</label>
+                            <select id="map-y-property" class="form-select"></select>
                         </div>
 
                         <button
                             class="btn btn-sm btn-secondary chsp-extra-options-btn"
                             type="button"
-                            data-toggle="collapse"
-                            data-target="#map-y-extra"
+                            data-bs-toggle="collapse"
+                            data-bs-target="#map-y-extra"
                         >
                             more options
                         </button>
 
                         <div class="collapse chsp-map-extra-options" id="map-y-extra">
                             <div class="input-group input-group-sm">
-                                <div class="input-group-prepend">
-                                    <label class="input-group-text" for="map-y-scale">scale:</label>
-                                </div>
-                                <select id="map-y-scale" class="custom-select">
+                                <label class="input-group-text" for="map-y-scale">scale:</label>
+                                <select id="map-y-scale" class="form-select">
                                     <option value="linear">linear</option>
                                     <option value="log">log</option>
                                 </select>
                             </div>
 
                             <div class="input-group input-group-sm">
-                                <div class="input-group-prepend">
-                                    <label id="map-y-min-label" class="input-group-text" for="map-y-min">min:</label>
-                                </div>
+                                <label id="map-y-min-label" class="input-group-text" for="map-y-min">min:</label>
                                 <input id="map-y-min" class="form-control" type="number" step="any" />
                             </div>
 
                             <div class="input-group input-group-sm">
-                                <div class="input-group-prepend">
-                                    <label id="map-y-max-label" class="input-group-text" for="map-y-max">max:</label>
-                                </div>
+                                <label id="map-y-max-label" class="input-group-text" for="map-y-max">max:</label>
                                 <input id="map-y-max" class="form-control" type="number" step="any" />
                             </div>
                         </div>
 
                         <div class="input-group input-group-sm">
-                            <div class="input-group-prepend">
-                                <label class="input-group-text" for="map-z-property">z axis:</label>
-                            </div>
-                            <select id="map-z-property" class="custom-select">
+                            <label class="input-group-text" for="map-z-property">z axis:</label>
+                            <select id="map-z-property" class="form-select">
                                 <option value="">none</option>
                             </select>
                         </div>
@@ -106,34 +88,28 @@
                         <button
                             class="btn btn-sm btn-secondary chsp-extra-options-btn"
                             type="button"
-                            data-toggle="collapse"
-                            data-target="#map-z-extra"
+                            data-bs-toggle="collapse"
+                            data-bs-target="#map-z-extra"
                         >
                             more options
                         </button>
 
                         <div class="collapse chsp-map-extra-options" id="map-z-extra">
                             <div class="input-group input-group-sm">
-                                <div class="input-group-prepend">
-                                    <label class="input-group-text" for="map-z-scale">scale:</label>
-                                </div>
-                                <select id="map-z-scale" class="custom-select" disabled>
+                                <label class="input-group-text" for="map-z-scale">scale:</label>
+                                <select id="map-z-scale" class="form-select" disabled>
                                     <option value="linear">linear</option>
                                     <option value="log">log</option>
                                 </select>
                             </div>
 
                             <div class="input-group input-group-sm">
-                                <div class="input-group-prepend">
-                                    <label id="map-z-min-label" class="input-group-text" for="map-z-min">min:</label>
-                                </div>
+                                <label id="map-z-min-label" class="input-group-text" for="map-z-min">min:</label>
                                 <input id="map-z-min" class="form-control" type="number" step="any" disabled />
                             </div>
 
                             <div class="input-group input-group-sm">
-                                <div class="input-group-prepend">
-                                    <label id="map-z-max-label" class="input-group-text" for="map-z-max">max:</label>
-                                </div>
+                                <label id="map-z-max-label" class="input-group-text" for="map-z-max">max:</label>
                                 <input id="map-z-max" class="form-control" type="number" step="any" disabled />
                             </div>
                         </div>
@@ -143,10 +119,8 @@
                     <h5 class="chsp-settings-section-title">Style</h5>
                     <div class="chsp-map-options">
                         <div class="input-group input-group-sm">
-                            <div class="input-group-prepend">
-                                <label class="input-group-text" for="map-color-property">color:</label>
-                            </div>
-                            <select id="map-color-property" class="custom-select">
+                            <label class="input-group-text" for="map-color-property">color:</label>
+                            <select id="map-color-property" class="form-select">
                                 <option value="">fixed</option>
                             </select>
                         </div>
@@ -154,8 +128,8 @@
                         <button
                             class="btn btn-sm btn-secondary chsp-extra-options-btn"
                             type="button"
-                            data-toggle="collapse"
-                            data-target="#map-color-extra"
+                            data-bs-toggle="collapse"
+                            data-bs-target="#map-color-extra"
                         >
                             more options
                         </button>
@@ -164,34 +138,26 @@
                             <button class="btn btn-sm btn-light" type="button" id="map-color-reset" style="width: 100%">reset</button>
 
                             <div class="input-group input-group-sm">
-                                <div class="input-group-prepend">
-                                    <label class="input-group-text" for="map-color-min">min:</label>
-                                </div>
+                                <label class="input-group-text" for="map-color-min">min:</label>
                                 <input id="map-color-min" class="form-control" type="number" step="any" />
                             </div>
 
                             <div class="input-group input-group-sm">
-                                <div class="input-group-prepend">
-                                    <label class="input-group-text" for="map-color-max">max:</label>
-                                </div>
+                                <label class="input-group-text" for="map-color-max">max:</label>
                                 <input id="map-color-max" class="form-control" type="number" step="any" />
                             </div>
 
                             <div class="chsp-map-options" style="grid-column: 1 / 3">
                                 <div class="input-group input-group-sm">
-                                    <div class="input-group-prepend">
-                                        <label class="input-group-text" for="map-color-palette">palette:</label>
-                                    </div>
-                                    <select id="map-color-palette" class="custom-select"></select>
+                                    <label class="input-group-text" for="map-color-palette">palette:</label>
+                                    <select id="map-color-palette" class="form-select"></select>
                                 </div>
                             </div>
                         </div>
 
                         <div class="input-group input-group-sm">
-                            <div class="input-group-prepend">
-                                <label class="input-group-text" for="map-size-property">size:</label>
-                            </div>
-                            <select id="map-size-property" class="custom-select">
+                            <label class="input-group-text" for="map-size-property">size:</label>
+                            <select id="map-size-property" class="form-select">
                                 <option value="">fixed</option>
                             </select>
                         </div>
@@ -199,41 +165,35 @@
                         <button
                             class="btn btn-sm btn-secondary chsp-extra-options-btn"
                             type="button"
-                            data-toggle="collapse"
-                            data-target="#map-size-extra"
+                            data-bs-toggle="collapse"
+                            data-bs-target="#map-size-extra"
                         >
                             more options
                         </button>
 
                         <div class="collapse chsp-map-extra-options" id="map-size-extra" style="grid-template-columns: 1fr 1fr">
                             <div class="input-group input-group-sm">
-                                <div class="input-group-prepend">
-                                    <label class="input-group-text" for="map-size-scale">size scale:</label>
-                                </div>
-                                <select id="map-size-scale" class="custom-select" disabled>
+                                <label class="input-group-text" for="map-size-scale">size scale:</label>
+                                <select id="map-size-scale" class="form-select" disabled>
                                     <option value="linear">linear</option>
                                     <option value="log">log</option>
                                     <option value="sqrt">sqrt</option>
                                     <option value="inverse">inverse</option>
                                 </select>
                             </div>
-                            <div class="custom-switch">
-                                <input class="custom-control-input" id="map-size-reverse" type="checkbox" disabled />
-                                <label class="custom-control-label" for="map-size-reverse" title="reverse sizes">reverse sizes</label>
+                            <div class="form-check form-switch">
+                                <input class="form-check-input" id="map-size-reverse" type="checkbox" disabled />
+                                <label class="form-check-label" for="map-size-reverse" title="reverse sizes">reverse sizes</label>
                             </div>
                             <div class="input-group input-group-sm" style="grid-column: auto / span 2">
-                                <div class="input-group-prepend">
-                                    <label class="input-group-text" for="map-size-factor">factor:</label>
-                                </div>
-                                <input type="range" min="1" max="100" step="1" class="form-control custom-range" id="map-size-factor" />
+                                <label class="input-group-text" for="map-size-factor">factor:</label>
+                                <input type="range" min="1" max="100" step="1" class="form-control form-range" id="map-size-factor" />
                             </div>
                         </div>
 
                         <div class="input-group input-group-sm">
-                            <div class="input-group-prepend">
-                                <label class="input-group-text" for="map-symbol-property">symbol:</label>
-                            </div>
-                            <select id="map-symbol-property" class="custom-select">
+                            <label class="input-group-text" for="map-symbol-property">symbol:</label>
+                            <select id="map-symbol-property" class="form-select">
                                 <option value="">fixed</option>
                             </select>
                         </div>

--- a/src/map/options.ts
+++ b/src/map/options.ts
@@ -182,7 +182,7 @@ export class MapOptions extends OptionsGroup {
      */
     public remove(): void {
         if (this._modal.classList.contains('show')) {
-            const close = this._modal.querySelector('.close');
+            const close = this._modal.querySelector('.btn-close');
             assert(close !== null);
             (close as HTMLElement).click();
         }
@@ -305,8 +305,8 @@ export class MapOptions extends OptionsGroup {
         const template = document.createElement('template');
         template.innerHTML = `<button
             class="btn btn-light btn-sm chsp-viewer-button"
-            data-target='#${this.getId('map-settings')}'
-            data-toggle="modal"
+            data-bs-target='#${this.getId('map-settings')}'
+            data-bs-toggle="modal"
             style="top: 4px; left: 5px; opacity: 1;">
                 <div>${BARS_SVG}</div>
             </button>`;
@@ -318,7 +318,7 @@ export class MapOptions extends OptionsGroup {
         template.innerHTML = HTML_OPTIONS
             .replace(/id="(.*?)"/g, (_: string, id: string) => `id="${this.getId(id)}"`)
             .replace(/for="(.*?)"/g, (_: string, id: string) => `for="${this.getId(id)}"`)
-            .replace(/data-target="#(.*?)"/g, (_: string, id: string) => `data-target="#${this.getId(id)}"`);
+            .replace(/data-bs-target="#(.*?)"/g, (_: string, id: string) => `data-bs-target="#${this.getId(id)}"`);
 
         const modal = template.content.firstChild as HTMLElement;
         const modalDialog = modal.childNodes[1] as HTMLElement;

--- a/src/metadata.ts
+++ b/src/metadata.ts
@@ -12,8 +12,8 @@ import { generateGUID, getElement } from './utils';
 import INFO_SVG from './static/info.svg';
 
 function generateName(guid: string, name: string): string {
-    return `<div data-toggle="modal" data-target="#${guid}">
-    <span> ${name} </span> 
+    return `<div data-bs-toggle="modal" data-bs-target="#${guid}">
+    <span> ${name} </span>
     <div class='chsp-info-icon'>${INFO_SVG}</div>
     </div>`;
 }
@@ -56,7 +56,7 @@ function generateModal(guid: string, metadata: Metadata): string {
             <div class="modal-content">
                 <div class="modal-header chsp-modal-header">
                     <h4 class="modal-title">${metadata.name}</h4>
-                    <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                 </div>
                 <div class="modal-body">
                     <div>${md.render(description)}</div>
@@ -123,7 +123,7 @@ export class MetadataPanel {
     public remove(): void {
         this._name.innerHTML = '';
         if (this._modal.classList.contains('show')) {
-            const close = this._modal.querySelector('.close');
+            const close = this._modal.querySelector('.btn-close');
             assert(close !== null);
             (close as HTMLElement).click();
         }

--- a/src/static/chemiscope.css
+++ b/src/static/chemiscope.css
@@ -164,7 +164,7 @@
     min-width: 6em;
 }
 
-.chsp-map-options > :nth-child(n+3):not(.chsp-map-extra-options) {
+.chsp-map-options > :nth-child(n + 3):not(.chsp-map-extra-options) {
     margin-top: 1rem;
 }
 

--- a/src/static/chemiscope.css
+++ b/src/static/chemiscope.css
@@ -157,20 +157,27 @@
     align-items: center;
     justify-content: center;
     align-content: start;
-    grid-gap: 1em;
+    column-gap: 1em;
 }
 
 .chsp-map-options label {
     min-width: 6em;
 }
 
+.chsp-map-options > :nth-child(n+3):not(.chsp-map-extra-options) {
+    margin-top: 1rem;
+}
+
 .chsp-map-extra-options {
     display: grid;
     align-items: center;
     justify-items: center;
-    grid-template-columns: 0.75fr 1fr 1fr;
-    grid-gap: 1em;
-    margin-bottom: 1.5em;
+    grid-template-columns: auto 1fr 1fr;
+    column-gap: 1em;
+}
+
+.chsp-map-extra-options > * {
+    margin: 1em 0;
 }
 
 .chsp-map-extra-options label {

--- a/src/structure/options.html
+++ b/src/structure/options.html
@@ -5,30 +5,30 @@
             <div class="modal-content">
                 <div class="modal-header chsp-modal-header">
                     <h4 class="modal-title">Visualizer settings</h4>
-                    <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                 </div>
                 <div class="modal-body">
                     <h5 class="chsp-settings-section-title">Representation</h5>
                     <div class="chsp-settings-representation">
-                        <div class="custom-control custom-switch">
-                            <input class="custom-control-input" id="bonds" type="checkbox" />
-                            <label class="custom-control-label" for="bonds" title="show bonds between atoms">bonds</label>
+                        <div class="form-check form-switch">
+                            <input class="form-check-input" id="bonds" type="checkbox" />
+                            <label class="form-check-label" for="bonds" title="show bonds between atoms">bonds</label>
                         </div>
-                        <div class="custom-control custom-switch">
-                            <input class="custom-control-input" id="space-filling" type="checkbox" />
-                            <label class="custom-control-label" for="space-filling" title="show atoms as spheres">space filling</label>
+                        <div class="form-check form-switch">
+                            <input class="form-check-input" id="space-filling" type="checkbox" />
+                            <label class="form-check-label" for="space-filling" title="show atoms as spheres">space filling</label>
                         </div>
-                        <div class="custom-control custom-switch">
-                            <input class="custom-control-input" id="atom-labels" type="checkbox" />
-                            <label class="custom-control-label" for="atom-labels" title="show element symbols">atom labels</label>
+                        <div class="form-check form-switch">
+                            <input class="form-check-input" id="atom-labels" type="checkbox" />
+                            <label class="form-check-label" for="atom-labels" title="show element symbols">atom labels</label>
                         </div>
-                        <div class="custom-control custom-switch chsp-hide-if-no-cell">
-                            <input class="custom-control-input" id="unit-cell" type="checkbox" />
-                            <label class="custom-control-label" for="unit-cell" title="show the unit cell">unit cell</label>
+                        <div class="form-check form-switch chsp-hide-if-no-cell">
+                            <input class="form-check-input" id="unit-cell" type="checkbox" />
+                            <label class="form-check-label" for="unit-cell" title="show the unit cell">unit cell</label>
                         </div>
-                        <div class="custom-control custom-switch">
-                            <input class="custom-control-input" id="rotation" type="checkbox" />
-                            <label class="custom-control-label" for="rotation" title="rotate the camera continuously">rotation</label>
+                        <div class="form-check form-switch">
+                            <input class="form-check-input" id="rotation" type="checkbox" />
+                            <label class="form-check-label" for="rotation" title="rotate the camera continuously">rotation</label>
                         </div>
                     </div>
 
@@ -37,21 +37,15 @@
                         <h5 class="chsp-settings-section-title">Supercell</h5>
                         <div class="chsp-settings-supercell">
                             <span class="input-group input-group-sm">
-                                <div class="input-group-prepend">
-                                    <label class="input-group-text" for="supercell-a">X:</label>
-                                </div>
+                                <label class="input-group-text" for="supercell-a">X:</label>
                                 <input class="form-control chsp-supercell-count" id="supercell-a" type="number" min="1" max="10" />
                             </span>
                             <span class="input-group input-group-sm">
-                                <div class="input-group-prepend">
-                                    <label class="input-group-text" for="supercell-b">Y:</label>
-                                </div>
+                                <label class="input-group-text" for="supercell-b">Y:</label>
                                 <input class="form-control chsp-supercell-count" id="supercell-b" type="number" min="1" max="10" />
                             </span>
                             <span class="input-group input-group-sm">
-                                <div class="input-group-prepend">
-                                    <label class="input-group-text" for="supercell-c">Z:</label>
-                                </div>
+                                <label class="input-group-text" for="supercell-c">Z:</label>
                                 <input class="form-control chsp-supercell-count" id="supercell-c" type="number" min="1" max="10" />
                             </span>
                             <button class="btn btn-primary btn-sm" id="reset-supercell">reset supercell</button>
@@ -60,10 +54,8 @@
 
                     <div style="margin-bottom: 0.8em"></div>
                     <div class="input-group input-group-sm">
-                        <div class="input-group-prepend">
-                            <label class="input-group-text" for="axes">Axes:</label>
-                        </div>
-                        <select id="axes" class="custom-select">
+                        <label class="input-group-text" for="axes">Axes:</label>
+                        <select id="axes" class="form-select">
                             <option value="off" selected>off</option>
                             <option value="xyz">xyz</option>
                             <option class="chsp-hide-if-no-cell" value="abc">abc</option>
@@ -74,15 +66,12 @@
                         <div style="margin-bottom: 1.5em"></div>
                         <h5 class="chsp-settings-section-title">Environments</h5>
                         <div class="chsp-settings-environments">
-                            <div class="btn-group-toggle" data-toggle="buttons">
-                                <label class="btn btn-primary btn-sm active" style="width: 100%">
-                                    <input type="checkbox" id="env-activated" checked /> Disable
-                                </label>
-                            </div>
-                            <div class="custom-control custom-switch">
-                                <input type="checkbox" class="custom-control-input" id="env-center" />
+                            <input type="checkbox" id="env-activated" class="btn-check" checked />
+                            <label class="btn btn-primary btn-sm active" for="env-activated">Disable</label>
+                            <div class="form-check form-switch">
+                                <input type="checkbox" class="form-check-input" id="env-center" />
                                 <label
-                                    class="custom-control-label"
+                                    class="form-check-label"
                                     for="env-center"
                                     title="center automatically structure or environment in the viewport"
                                     style="cursor: help"
@@ -93,8 +82,8 @@
                             <button
                                 class="btn btn-sm btn-secondary chsp-extra-options-btn"
                                 type="button"
-                                data-toggle="collapse"
-                                data-target="#chsp-extra-env"
+                                data-bs-toggle="collapse"
+                                data-bs-target="#chsp-extra-env"
                                 id="chsp-env-more"
                             >
                                 more options
@@ -104,9 +93,7 @@
                                     <span style="vertical-align: middle">Highlight region</span>
                                 </div>
                                 <div class="input-group input-group-sm">
-                                    <div class="input-group-prepend">
-                                        <label class="input-group-text" for="env-cutoff">cutoff</label>
-                                    </div>
+                                    <label class="input-group-text" for="env-cutoff">cutoff</label>
                                     <input class="form-control" id="env-cutoff" type="number" min="0" max="50" step="0.1" />
                                 </div>
                                 <button class="btn btn-sm btn-light" id="env-reset">reset</button>
@@ -114,19 +101,15 @@
                                     <span style="vertical-align: middle">Background atoms</span>
                                 </div>
                                 <div class="input-group input-group-sm">
-                                    <div class="input-group-prepend">
-                                        <label class="input-group-text" for="env-bg-color">color</label>
-                                    </div>
-                                    <select id="env-bg-color" class="custom-select">
+                                    <label class="input-group-text" for="env-bg-color">color</label>
+                                    <select id="env-bg-color" class="form-select">
                                         <option value="CPK">CPK</option>
                                         <option value="grey">grey</option>
                                     </select>
                                 </div>
                                 <div class="input-group input-group-sm">
-                                    <div class="input-group-prepend">
-                                        <label class="input-group-text" for="env-bg-style">style</label>
-                                    </div>
-                                    <select id="env-bg-style" class="custom-select">
+                                    <label class="input-group-text" for="env-bg-style">style</label>
+                                    <select id="env-bg-style" class="form-select">
                                         <option value="licorice">licorice</option>
                                         <option value="ball-stick">ball and stick</option>
                                         <option value="hide">hide</option>
@@ -154,22 +137,15 @@
                         <h5 class="chsp-settings-section-title">Trajectory</h5>
                         <div class="chsp-settings-trajectory">
                             <div class="input-group input-group-sm">
-                                <div class="input-group-prepend">
-                                    <label
-                                        class="input-group-text"
-                                        for="playback-delay"
-                                        title="playback delay in tenths of seconds"
-                                        style="cursor: help"
-                                    >
-                                        playback delay
-                                    </label>
-                                </div>
+                                <label class="input-group-text" for="playback-delay" title="playback delay in tenths of seconds" style="cursor: help">
+                                    playback delay
+                                </label>
                                 <input id="playback-delay" class="form-control" type="number" min="1" value="7" />
                             </div>
-                            <div class="custom-control custom-switch">
-                                <input type="checkbox" class="custom-control-input" id="keep-orientation" />
+                            <div class="form-check form-switch">
+                                <input type="checkbox" class="form-check-input" id="keep-orientation" />
                                 <label
-                                    class="custom-control-label"
+                                    class="form-check-label"
                                     for="keep-orientation"
                                     title="keep the camera orientation when loading a new molecule"
                                     style="cursor: help"

--- a/src/structure/options.ts
+++ b/src/structure/options.ts
@@ -117,7 +117,7 @@ export class StructureOptions extends OptionsGroup {
      */
     public remove(): void {
         if (this._modal.classList.contains('show')) {
-            const close = this._modal.querySelector('.close');
+            const close = this._modal.querySelector('.btn-close');
             assert(close !== null);
             (close as HTMLElement).click();
         }
@@ -158,8 +158,8 @@ export class StructureOptions extends OptionsGroup {
         const template = document.createElement('template');
         template.innerHTML = `<button
             class="btn btn-light btn-sm chsp-viewer-button"
-            data-target="#${guid}-structure-settings"
-            data-toggle="modal"
+            data-bs-target="#${guid}-structure-settings"
+            data-bs-toggle="modal"
             style="top: 4px; right: 4px; opacity: 1;">
                 <div>${BARS_SVG}</div>
             </button>`;
@@ -171,7 +171,7 @@ export class StructureOptions extends OptionsGroup {
         template.innerHTML = HTML_OPTIONS
             .replace(/id="(.*?)"/g, (_: string, id: string) => `id="${guid}-${id}"`)
             .replace(/for="(.*?)"/g, (_: string, id: string) => `for="${guid}-${id}"`)
-            .replace(/data-target="#(.*?)"/g, (_: string, id: string) => `data-target="#${guid}-${id}"`);
+            .replace(/data-bs-target="#(.*?)"/g, (_: string, id: string) => `data-bs-target="#${guid}-${id}"`);
 
         const modal = template.content.firstChild as HTMLElement;
         const modalDialog = modal.childNodes[1] as HTMLElement;

--- a/src/structure/widget.ts
+++ b/src/structure/widget.ts
@@ -202,7 +202,8 @@ export class MoleculeViewer {
             'chsp-cell-info',
             'chsp-hide-if-no-cell',
             'badge',
-            'badge-light'
+            'bg-light',
+            'text-dark'
         );
         this._root.appendChild(this._cellInfo);
 
@@ -925,9 +926,7 @@ export class MoleculeViewer {
      * related to environments
      */
     private _enableEnvironmentSettings(show: boolean): void {
-        const toggleGroup = getByID(`${this.guid}-env-activated`);
-        assert(toggleGroup.parentElement !== null);
-        const toggle = toggleGroup.parentElement.lastChild;
+        const toggle = getByID(`${this.guid}-env-activated`).nextElementSibling as HTMLLabelElement;
         assert(toggle !== null);
         const reset = this._resetEnvCutoff;
 
@@ -938,7 +937,7 @@ export class MoleculeViewer {
             }
 
             reset.disabled = false;
-            toggle.nodeValue = 'Disable';
+            toggle.innerText = 'Disable';
 
             this._options.environments.cutoff.enable();
             this._options.environments.bgStyle.enable();
@@ -950,7 +949,7 @@ export class MoleculeViewer {
             }
 
             reset.disabled = true;
-            toggle.nodeValue = 'Enable';
+            toggle.innerText = 'Enable';
 
             this._options.environments.cutoff.disable();
             this._options.environments.bgStyle.disable();


### PR DESCRIPTION
Some elements might appear different now for two reasons:
- The appearance of certain components changed between Bootstrap 4 and 5.
- Others relied on hacks that no longer work or features that no longer exist in Bootstrap 5, therefore I added a replacement solution that might look a little different.

See the [Bootstrap migration guide](https://getbootstrap.com/docs/5.0/migration/) for reference.
Partially fixes #194.

As I understand it, the docs use sphinx-bootstrap-theme which is blocked at Bootstrap 3, so there is no update possible for now.

---

Edit (@Luthaf):
fixes #162