### PR TITLE
Interface to pass settings to chemiscope widgets

### DIFF
--- a/python/chemiscope/input.py
+++ b/python/chemiscope/input.py
@@ -279,10 +279,9 @@ def create_input(
                 data["properties"][name] = value
 
     if settings != "":
-        try:
-            data["settings"] = json.loads(settings)
-        except:
-            raise ValueError("`settings` should be a valid JSON string")
+        # Converts to a dictionary, checkign in passing that the JSON string is valid
+        data["settings"] = json.loads(settings)
+
     return data
 
 

--- a/python/chemiscope/input.py
+++ b/python/chemiscope/input.py
@@ -97,7 +97,12 @@ def _expand_properties(short_properties, n_structures, n_atoms):
 
 
 def create_input(
-    frames=None, meta=None, properties=None, environments=None, composition=False
+    frames=None,
+    meta=None,
+    properties=None,
+    environments=None,
+    composition=False,
+    settings="",
 ):
     """
     Create a dictionary that can be saved to JSON using the format used by
@@ -115,6 +120,9 @@ def create_input(
     :param bool composition: optional, ``False`` by default. If ``True``, will
         add to structure and atom properties containing information about the
         chemical composition
+    :param str settings: optional. "" by default. If provided, it should be a
+        JSON string with the visualization options that should be used to initialize
+        the viewer.
 
     The dataset metadata should be given in the ``meta`` dictionary, the
     possible keys are:
@@ -270,6 +278,11 @@ def create_input(
 
                 data["properties"][name] = value
 
+    if settings != "":
+        try:
+            data["settings"] = json.loads(settings)
+        except:
+            raise ValueError("`settings` should be a valid JSON string")
     return data
 
 
@@ -280,6 +293,7 @@ def write_input(
     properties=None,
     environments=None,
     composition=False,
+    settings="",
 ):
     """
     Create the input JSON file used by the default chemiscope visualizer, and
@@ -299,6 +313,9 @@ def write_input(
     :param bool composition: optional. False by default. If True, will add to
                                 the structure and atom properties information
                                 about chemical composition
+    :param str settings: optional. "" by default. If provided, it should be a
+        JSON string with the visualization options that should be used to initialize
+        the viewer.
 
     This function uses :py:func:`create_input` to generate the input data, see
     the documentation of this function for more information.
@@ -356,7 +373,7 @@ def write_input(
     if not (path.endswith(".json") or path.endswith(".json.gz")):
         raise Exception("path should end with .json or .json.gz")
 
-    data = create_input(frames, meta, properties, environments, composition)
+    data = create_input(frames, meta, properties, environments, composition, settings)
 
     if "name" not in data["meta"] or data["meta"]["name"] == "<unknown>":
         data["meta"]["name"] = os.path.basename(path).split(".")[0]

--- a/python/chemiscope/input.py
+++ b/python/chemiscope/input.py
@@ -120,7 +120,7 @@ def create_input(
     :param bool composition: optional, ``False`` by default. If ``True``, will
         add to structure and atom properties containing information about the
         chemical composition
-    :param str settings: optional. "" by default. If provided, it should be a
+    :param str settings: optional. "" by default. If provided, it must be a
         JSON string with the visualization options that should be used to initialize
         the viewer.
 
@@ -313,7 +313,7 @@ def write_input(
     :param bool composition: optional. False by default. If True, will add to
                                 the structure and atom properties information
                                 about chemical composition
-    :param str settings: optional. "" by default. If provided, it should be a
+    :param str settings: optional. "" by default. If provided, it must be a
         JSON string with the visualization options that should be used to initialize
         the viewer.
 

--- a/python/chemiscope/jupyter.py
+++ b/python/chemiscope/jupyter.py
@@ -7,15 +7,21 @@ from traitlets import Unicode, Bool
 from .input import create_input
 
 
-class _ChemiscopeWidgetBase:
+class _ChemiscopeWidgetBase(ipywidgets.DOMWidget, ipywidgets.ValueWidget):
     """Base class to hold member functions that are common to the different
     types of chemiscope modes"""
+
+    data = Unicode().tag(sync=True)
+    settings = Unicode().tag(sync=True)
+    has_metadata = Bool().tag(sync=True)
 
     def save(self, path):
         """
         Save the dataset displayed by this :py:class:`ChemiscopeWidget` as JSON
         to the given ``path``. If ``path`` ends with ``.gz``, the file is
         written as gzip compressed JSON string.
+        NB: this is the data as of the creation of the widget, the style does
+        not get dynamically updated.
 
         :param str path: where to save the dataset.
         """
@@ -29,15 +35,10 @@ class _ChemiscopeWidgetBase:
 
 
 @ipywidgets.register
-class ChemiscopeWidget(
-    ipywidgets.DOMWidget, ipywidgets.ValueWidget, _ChemiscopeWidgetBase
-):
+class ChemiscopeWidget(_ChemiscopeWidgetBase):
     _view_name = Unicode("ChemiscopeView").tag(sync=True)
     _view_module = Unicode("chemiscope-widget").tag(sync=True)
 
-    data = Unicode().tag(sync=True)
-    has_metadata = Bool().tag(sync=True)
-
     def __init__(self, data, has_metadata):
         super().__init__()
         self.data = json.dumps(data)
@@ -45,15 +46,10 @@ class ChemiscopeWidget(
 
 
 @ipywidgets.register
-class StructureWidget(
-    ipywidgets.DOMWidget, ipywidgets.ValueWidget, _ChemiscopeWidgetBase
-):
+class StructureWidget(_ChemiscopeWidgetBase):
     _view_name = Unicode("StructureView").tag(sync=True)
     _view_module = Unicode("chemiscope-widget").tag(sync=True)
 
-    data = Unicode().tag(sync=True)
-    has_metadata = Bool().tag(sync=True)
-
     def __init__(self, data, has_metadata):
         super().__init__()
         self.data = json.dumps(data)
@@ -61,12 +57,9 @@ class StructureWidget(
 
 
 @ipywidgets.register
-class MapWidget(ipywidgets.DOMWidget, ipywidgets.ValueWidget, _ChemiscopeWidgetBase):
+class MapWidget(_ChemiscopeWidgetBase):
     _view_name = Unicode("MapView").tag(sync=True)
     _view_module = Unicode("chemiscope-widget").tag(sync=True)
-
-    data = Unicode().tag(sync=True)
-    has_metadata = Bool().tag(sync=True)
 
     def __init__(self, data, has_metadata):
         super().__init__()

--- a/python/chemiscope/jupyter.py
+++ b/python/chemiscope/jupyter.py
@@ -7,18 +7,9 @@ from traitlets import Unicode, Bool
 from .input import create_input
 
 
-@ipywidgets.register
-class ChemiscopeWidget(ipywidgets.DOMWidget, ipywidgets.ValueWidget):
-    _view_name = Unicode("ChemiscopeView").tag(sync=True)
-    _view_module = Unicode("chemiscope-widget").tag(sync=True)
-
-    data = Unicode().tag(sync=True)
-    has_metadata = Bool().tag(sync=True)
-
-    def __init__(self, data, has_metadata):
-        super().__init__()
-        self.data = json.dumps(data)
-        self.has_metadata = has_metadata
+class _ChemiscopeWidgetBase:
+    """Base class to hold member functions that are common to the different
+    types of chemiscope modes"""
 
     def save(self, path):
         """
@@ -38,7 +29,25 @@ class ChemiscopeWidget(ipywidgets.DOMWidget, ipywidgets.ValueWidget):
 
 
 @ipywidgets.register
-class StructureWidget(ipywidgets.DOMWidget, ipywidgets.ValueWidget):
+class ChemiscopeWidget(
+    ipywidgets.DOMWidget, ipywidgets.ValueWidget, _ChemiscopeWidgetBase
+):
+    _view_name = Unicode("ChemiscopeView").tag(sync=True)
+    _view_module = Unicode("chemiscope-widget").tag(sync=True)
+
+    data = Unicode().tag(sync=True)
+    has_metadata = Bool().tag(sync=True)
+
+    def __init__(self, data, has_metadata):
+        super().__init__()
+        self.data = json.dumps(data)
+        self.has_metadata = has_metadata
+
+
+@ipywidgets.register
+class StructureWidget(
+    ipywidgets.DOMWidget, ipywidgets.ValueWidget, _ChemiscopeWidgetBase
+):
     _view_name = Unicode("StructureView").tag(sync=True)
     _view_module = Unicode("chemiscope-widget").tag(sync=True)
 
@@ -52,7 +61,7 @@ class StructureWidget(ipywidgets.DOMWidget, ipywidgets.ValueWidget):
 
 
 @ipywidgets.register
-class MapWidget(ipywidgets.DOMWidget, ipywidgets.ValueWidget):
+class MapWidget(ipywidgets.DOMWidget, ipywidgets.ValueWidget, _ChemiscopeWidgetBase):
     _view_name = Unicode("MapView").tag(sync=True)
     _view_module = Unicode("chemiscope-widget").tag(sync=True)
 
@@ -65,7 +74,14 @@ class MapWidget(ipywidgets.DOMWidget, ipywidgets.ValueWidget):
         self.has_metadata = has_metadata
 
 
-def show(frames=None, properties=None, meta=None, environments=None, mode="default"):
+def show(
+    frames=None,
+    properties=None,
+    meta=None,
+    environments=None,
+    settings="",
+    mode="default",
+):
     """
     Show the dataset defined by the given ``frames`` and ``properties``
     (optionally ``meta`` and ``environments`` as well) using a embedded chemiscope
@@ -140,7 +156,11 @@ def show(frames=None, properties=None, meta=None, environments=None, mode="defau
         )
 
     dict_input = create_input(
-        frames=frames, properties=properties, meta=meta, environments=environments
+        frames=frames,
+        properties=properties,
+        meta=meta,
+        environments=environments,
+        settings=settings,
     )
 
     if mode != "structure":

--- a/python/nbextension/src/widget.ts
+++ b/python/nbextension/src/widget.ts
@@ -74,15 +74,15 @@ export class ChemiscopeView extends DOMWidgetView {
 
         const json_data = JSON.parse(this.model.get('data'));
         const dataset = json_data as Dataset;
-        const settings = json_data.settings as Partial<Settings> | undefined;
 
         const config = {
             meta: getByID(`${this.guid}-chemiscope-meta`, element),
             map: getByID(`${this.guid}-chemiscope-map`, element),
             structure: getByID(`${this.guid}-chemiscope-structure`, element),
             info: getByID(`${this.guid}-chemiscope-info`, element),
-            settings: settings,
             maxStructureViewers: 4,
+            // conditionally adds a settings field
+            ...('settings' in json_data && { settings: json_data.settings as Partial<Settings> }),
         };
 
         void DefaultVisualizer.load(config, dataset)
@@ -157,13 +157,13 @@ export class StructureView extends DOMWidgetView {
 
         const json_data = JSON.parse(this.model.get('data'));
         const dataset = json_data as Dataset;
-        const settings = json_data.settings as Partial<Settings> | undefined;
 
         const config = {
             meta: getByID(`${this.guid}-chemiscope-meta`, element),
             structure: getByID(`${this.guid}-chemiscope-structure`, element),
             info: getByID(`${this.guid}-chemiscope-info`, element),
-            settings: settings,
+            // conditionally adds a settings field
+            ...('settings' in json_data && { settings: json_data.settings as Partial<Settings> }),
         };
 
         // Python -> JavaScript update
@@ -200,7 +200,7 @@ export class StructureView extends DOMWidgetView {
     }
 
     public _SaveSettings(): void {
-        console.log('saving settings', this.visualizer);
+        console.log('saving settings', this, this.visualizer);
 
         if (this.visualizer !== undefined) {
             console.log(JSON.stringify(this.visualizer.structure.saveSettings()));
@@ -276,13 +276,13 @@ export class MapView extends DOMWidgetView {
 
         const json_data = JSON.parse(this.model.get('data'));
         const dataset = json_data as Dataset;
-        const settings = json_data.settings as Partial<Settings> | undefined;
 
         const config = {
             meta: getByID(`${this.guid}-chemiscope-meta`, element),
             map: getByID(`${this.guid}-chemiscope-map`, element),
             info: getByID(`${this.guid}-chemiscope-info`, element),
-            settings: settings,
+            // conditionally adds a settings field
+            ...('settings' in json_data && { settings: json_data.settings as Partial<Settings> }),
         };
 
         void MapVisualizer.load(config, dataset)

--- a/python/nbextension/src/widget.ts
+++ b/python/nbextension/src/widget.ts
@@ -6,7 +6,12 @@ import './widget.css';
 import './chemiscope-bootstrap.less';
 import 'bootstrap/dist/js/bootstrap.min.js';
 
-import { DefaultVisualizer, MapVisualizer, StructureVisualizer } from '../../../src/index';
+import {
+    DefaultVisualizer,
+    MapVisualizer,
+    StructureVisualizer,
+    Settings,
+} from '../../../src/index';
 import { Dataset } from '../../../src/dataset';
 
 /**
@@ -66,16 +71,20 @@ export class ChemiscopeView extends DOMWidgetView {
             </div>
         </div>`;
 
+        const json_data = JSON.parse(this.model.get('data'));
+        const dataset = json_data as Dataset;
+        const settings = json_data.settings as Partial<Settings> | undefined;
+
         const config = {
             meta: getByID(`${this.guid}-chemiscope-meta`, element),
             map: getByID(`${this.guid}-chemiscope-map`, element),
             structure: getByID(`${this.guid}-chemiscope-structure`, element),
             info: getByID(`${this.guid}-chemiscope-info`, element),
+            settings: settings,
             maxStructureViewers: 4,
         };
 
-        const data = JSON.parse(this.model.get('data')) as Dataset;
-        void DefaultVisualizer.load(config, data)
+        void DefaultVisualizer.load(config, dataset)
             .then((visualizer) => {
                 this.visualizer = visualizer;
             })
@@ -145,14 +154,18 @@ export class StructureView extends DOMWidgetView {
             </div>
         </div>`;
 
+        const json_data = JSON.parse(this.model.get('data'));
+        const dataset = json_data as Dataset;
+        const settings = json_data.settings as Partial<Settings> | undefined;
+
         const config = {
             meta: getByID(`${this.guid}-chemiscope-meta`, element),
             structure: getByID(`${this.guid}-chemiscope-structure`, element),
             info: getByID(`${this.guid}-chemiscope-info`, element),
+            settings: settings,
         };
 
-        const data = JSON.parse(this.model.get('data')) as Dataset;
-        void StructureVisualizer.load(config, data)
+        void StructureVisualizer.load(config, dataset)
             .then((visualizer) => {
                 this.visualizer = visualizer;
             })
@@ -229,14 +242,18 @@ export class MapView extends DOMWidgetView {
             </div>
         </div>`;
 
+        const json_data = JSON.parse(this.model.get('data'));
+        const dataset = json_data as Dataset;
+        const settings = json_data.settings as Partial<Settings> | undefined;
+
         const config = {
             meta: getByID(`${this.guid}-chemiscope-meta`, element),
             map: getByID(`${this.guid}-chemiscope-map`, element),
             info: getByID(`${this.guid}-chemiscope-info`, element),
+            settings: settings,
         };
 
-        const data = JSON.parse(this.model.get('data')) as Dataset;
-        void MapVisualizer.load(config, data)
+        void MapVisualizer.load(config, dataset)
             .then((visualizer) => {
                 this.visualizer = visualizer;
             })

--- a/python/nbextension/src/widget.ts
+++ b/python/nbextension/src/widget.ts
@@ -173,7 +173,16 @@ export class StructureView extends DOMWidgetView {
             .then((visualizer) => {
                 this.visualizer = visualizer;
                 this._SaveSettings();
-                this.visualizer.structure.onsettings = this._SaveSettings;
+                visualizer.structure.onsettings = () => {
+                    console.log(JSON.stringify(visualizer.structure.saveSettings()));
+                    this.model.set(
+                        'settings',
+                        JSON.stringify({ structure: visualizer.structure.saveSettings() })
+                    ); 
+                    this.model.save_changes();
+                };                    
+                console.log("Initializing callback0, this");
+                this.visualizer.structure.onsettings.bind(this);
             })
             .catch((e: Error) => {
                 const display = getByID(`${this.guid}-error-display`, element);
@@ -200,7 +209,8 @@ export class StructureView extends DOMWidgetView {
     }
 
     public _SaveSettings(): void {
-        console.log('saving settings', this, this.visualizer);
+        console.log('saving settings', this);
+        console.log("visualize", this.visualizer);
 
         if (this.visualizer !== undefined) {
             console.log(JSON.stringify(this.visualizer.structure.saveSettings()));

--- a/src/index.ts
+++ b/src/index.ts
@@ -483,6 +483,9 @@ class StructureVisualizer {
 
         this.structure.show(initial);
         this.info.show(initial);
+        if (config.settings && config.settings.structure) {
+            this.structure.applySettings(config.settings.structure);
+        }
     }
 
     /**
@@ -496,7 +499,7 @@ class StructureVisualizer {
 }
 
 /**
- * Configuration for the [[StructureVisualizer]]
+ * Configuration for the [[MapVisualizer]]
  */
 export interface MapConfig {
     /** Id of the DOM element to use for the [[PropertiesMap|properties map]] */
@@ -505,7 +508,7 @@ export interface MapConfig {
     info: string | HTMLElement;
     /** Id of the DOM element to use for the [[MetadataPanel|metadata display]] */
     meta: string | HTMLElement;
-    /** Settings for the map & structure viewer */
+    /** Settings for the map viewer */
     settings?: Partial<Settings>;
 }
 
@@ -583,6 +586,10 @@ class MapVisualizer {
 
         this.map.addMarker('map-0' as GUID, 'red', initial);
         this.info.show(initial);
+
+        if (config.settings && config.settings.map) {
+            this.map.applySettings(config.settings.map);
+        }
     }
 
     /**

--- a/src/structure/grid.ts
+++ b/src/structure/grid.ts
@@ -70,6 +70,8 @@ export class ViewersGrid {
     public onselect: (indexes: Indexes) => void;
     /** Callback fired when a viewer is removed from the grid */
     public onremove: (guid: GUID) => void;
+    /** Callback fired when settings of one of the viewers is changed */
+    public onsettings: () => void;
     /**
      * Callback fired when a new viewer is created
      *
@@ -167,6 +169,7 @@ export class ViewersGrid {
         this.onselect = () => {};
         this.onremove = () => {};
         this.oncreate = () => {};
+        this.onsettings = () => {};
         this.activeChanged = () => {};
         this.delayChanged = () => {};
 
@@ -661,6 +664,11 @@ export class ViewersGrid {
 
                     widget.highlight(atom);
                     this.onselect(indexes);
+                };
+
+                widget.onsettings = () => {
+                    console.log('overridden onsettings called');
+                    this.onsettings();
                 };
 
                 const current = { atom: undefined, structure: -1, environment: -1 };

--- a/src/structure/options.ts
+++ b/src/structure/options.ts
@@ -44,7 +44,7 @@ export class StructureOptions extends OptionsGroup {
     };
 
     /// The HTML element containing the settings modal
-    private _modal: HTMLElement;
+    public _modal: HTMLElement;
     /// The HTML element containing the button to open the settings modal
     private _openModal: HTMLElement;
     // Callback to get the initial positioning of the settings modal.

--- a/src/structure/widget.ts
+++ b/src/structure/widget.ts
@@ -210,6 +210,8 @@ export class MoleculeViewer {
             this.positionSettingsModal(rect)
         );
 
+        this._options._modal.onclose = this.onsettings;
+
         this._connectOptions();
         this._trajectoryOptions = getByID(`${this.guid}-trajectory-settings-group`);
 
@@ -263,6 +265,13 @@ export class MoleculeViewer {
             },
             { capture: true }
         );
+    }
+
+    /**
+     * Called when the settings modal is closed
+     */
+    public onsettings(): void {
+        console.log('original onsettings called');
     }
 
     /**

--- a/src/structure/widget.ts
+++ b/src/structure/widget.ts
@@ -210,7 +210,10 @@ export class MoleculeViewer {
             this.positionSettingsModal(rect)
         );
 
-        this._options._modal.onclose = this.onsettings;
+        this._options._modal.ontransitionend = () => {
+            console.log('modal event');
+            this.onsettings();
+        };
 
         this._connectOptions();
         this._trajectoryOptions = getByID(`${this.guid}-trajectory-settings-group`);


### PR DESCRIPTION
A minimalistic approach to defining settings of the chemiscope widget in a jupyter notebook. 
Basically one just passes the JSON string corresponding to the stored settings. 
Required cleaning up a bit here and there.