### PR TITLE
Isolate the map component

### DIFF
--- a/app/app.ts
+++ b/app/app.ts
@@ -1,7 +1,7 @@
 // load bootstrap: this needs to come first so that CSS files are loaded in the
 // right order
-require('bootstrap');
-require('bootstrap/dist/css/bootstrap.min.css');
+import 'bootstrap';
+import 'bootstrap/dist/css/bootstrap.min.css';
 
 import { getByID, addWarningHandler } from '../src/utils';
 import { Dataset, Structure } from '../src/dataset';
@@ -10,7 +10,7 @@ import { version, DefaultVisualizer, Settings } from '../src/index';
 import { inflate } from 'pako';
 
 // load CSS for the app
-require('./app.css');
+import './app.css';
 
 interface Configuration {
     /// optional callback to load the structures on demand.

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "bubleify": "^2.0.0",
         "buffer": "^6",
         "chai": "^4",
+        "construct-style-sheets-polyfill": "^3.1.0",
         "css-loader": "^6",
         "dts-bundle-generator": "^6.4",
         "eslint": "^8.7",
@@ -1851,7 +1852,9 @@
         "url": "https://opencollective.com/bootstrap"
       },
       "peerDependencies": {
-        "@popperjs/core": "^2.10.2"
+        "@popperjs/core": "^2.10.2",
+        "jquery": "1.9.1 - 3",
+        "popper.js": "^1.16.1"
       }
     },
     "node_modules/brace-expansion": {
@@ -2433,6 +2436,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/const-pinf-float64/-/const-pinf-float64-1.0.0.tgz",
       "integrity": "sha1-9u+w15+cCYbT558pI6v5twtj1yY=",
+      "dev": true
+    },
+    "node_modules/construct-style-sheets-polyfill": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/construct-style-sheets-polyfill/-/construct-style-sheets-polyfill-3.1.0.tgz",
+      "integrity": "sha512-HBLKP0chz8BAY6rBdzda11c3wAZeCZ+kIG4weVC2NM3AXzxx09nhe8t0SQNdloAvg5GLuHwq/0SPOOSPvtCcKw==",
       "dev": true
     },
     "node_modules/content-disposition": {
@@ -7752,6 +7761,18 @@
       "integrity": "sha1-tDkMLgedTCYtOyUExiiNlbp6R1g=",
       "dev": true
     },
+    "node_modules/popper.js": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1.tgz",
+      "integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ==",
+      "deprecated": "You can find the new Popper v2 at @popperjs/core, this package is dedicated to the legacy v1",
+      "dev": true,
+      "peer": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/popperjs"
+      }
+    },
     "node_modules/portfinder": {
       "version": "1.0.28",
       "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.28.tgz",
@@ -9362,6 +9383,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/terser/node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "extraneous": true
     },
     "node_modules/text-table": {
       "version": "0.2.0",
@@ -12942,6 +12969,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/const-pinf-float64/-/const-pinf-float64-1.0.0.tgz",
       "integrity": "sha1-9u+w15+cCYbT558pI6v5twtj1yY=",
+      "dev": true
+    },
+    "construct-style-sheets-polyfill": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/construct-style-sheets-polyfill/-/construct-style-sheets-polyfill-3.1.0.tgz",
+      "integrity": "sha512-HBLKP0chz8BAY6rBdzda11c3wAZeCZ+kIG4weVC2NM3AXzxx09nhe8t0SQNdloAvg5GLuHwq/0SPOOSPvtCcKw==",
       "dev": true
     },
     "content-disposition": {
@@ -17119,6 +17152,13 @@
       "resolved": "https://registry.npmjs.org/polybooljs/-/polybooljs-1.2.0.tgz",
       "integrity": "sha1-tDkMLgedTCYtOyUExiiNlbp6R1g=",
       "dev": true
+    },
+    "popper.js": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1.tgz",
+      "integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ==",
+      "dev": true,
+      "peer": true
     },
     "portfinder": {
       "version": "1.0.28",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "bubleify": "^2.0.0",
     "buffer": "^6",
     "chai": "^4",
+    "construct-style-sheets-polyfill": "^3.1.0",
     "css-loader": "^6",
     "dts-bundle-generator": "^6.4",
     "eslint": "^8.7",

--- a/python/nbextension/src/widget.css
+++ b/python/nbextension/src/widget.css
@@ -1,3 +1,7 @@
+html {
+    font-size: unset;
+}
+
 .chemiscope-meta-and-map {
     width: 100%;
     height: 100%;

--- a/src/collapse.ts
+++ b/src/collapse.ts
@@ -90,8 +90,8 @@ export default class Collapse {
      */
     static initialize(root: HTMLElement = document.body) {
         // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
-        for (const el of Array.from(root.querySelectorAll('[data-bs-toggle]')) as HTMLElement[]) {
-            if ('bsTarget' in el.dataset) {
+        for (const el of root.querySelectorAll('[data-bs-toggle]')) {
+            if (el instanceof HTMLElement && 'bsTarget' in el.dataset) {
                 const target: HTMLElement | null = root.querySelector(
                     (el.dataset as { bsTarget: string }).bsTarget
                 );

--- a/src/collapse.ts
+++ b/src/collapse.ts
@@ -1,0 +1,126 @@
+import assert from 'assert';
+
+/**
+ * Component for creating collapsible elements.
+ *
+ * Manipulated classes and styles are summarized here:
+ *  - Hidden:         .collapse
+ *  - Shown:          .collapse.show
+ *  - Hiding/showing: .collapsing, width/height
+ * The .collapse class should be present when calling the Collapse constructor.
+ * See [the Bootstrap docs](https://getbootstrap.com/docs/5.2/components/collapse/)
+ * for details.
+ */
+export default class Collapse {
+    private _horizontal: boolean;
+    private _property: 'width' | 'height';
+    private _visible: boolean = false;
+
+    /**
+     * Create a Collapse instance.
+     * @param _element The element to be made collapsible. It should have the
+     *  .collapse class.
+     */
+    constructor(private _element: HTMLElement) {
+        this._horizontal = this._element.classList.contains('horizontal');
+        this._property = this._horizontal ? 'width' : 'height';
+
+        this._element.addEventListener('transitionend', (event) => {
+            if (event.target === event.currentTarget && event.propertyName === this._property) {
+                this._element.classList.replace('collapsing', 'collapse');
+
+                if (this._visible) {
+                    this._element.classList.add('show');
+                    this._element.style.removeProperty(this._property);
+                }
+            }
+        });
+    }
+
+    hide() {
+        const size = this._element.getBoundingClientRect()[this._property];
+        this._element.style.setProperty(this._property, `${size}px`);
+
+        this._element.classList.replace('collapse', 'collapsing');
+        this._element.classList.remove('show');
+
+        // eslint-disable-next-line no-unused-expressions
+        this._element.offsetHeight;
+        this._element.style.removeProperty(this._property);
+
+        this._visible = false;
+    }
+
+    show() {
+        const scrollProperty = this._horizontal ? 'scrollWidth' : 'scrollHeight';
+
+        this._element.classList.replace('collapse', 'collapsing');
+        this._element.style.setProperty(this._property, '0');
+
+        const size = this._element[scrollProperty];
+        this._element.style.setProperty(this._property, `${size}px`);
+
+        this._visible = true;
+    }
+
+    toggle(value: boolean = !this._visible) {
+        if (value) {
+            this.show();
+        } else {
+            this.hide();
+        }
+    }
+
+    /**
+     * Set an element as a trigger for the collapsible element.
+     * @param el The element that should be set as a trigger.
+     */
+    addTrigger(el: HTMLElement) {
+        el.addEventListener('click', (event) => {
+            event.preventDefault();
+            this.toggle();
+        });
+    }
+
+    /**
+     * Scan the DOM for elements with the [data-bs-toggle] attribute to make
+     * them interactive with regards to this component.
+     *
+     * @param root The root element in which to scan.
+     */
+    static initialize(root: HTMLElement = document.body) {
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
+        for (const el of Array.from(root.querySelectorAll('[data-bs-toggle]')) as HTMLElement[]) {
+            if ('bsTarget' in el.dataset) {
+                const target: HTMLElement | null = root.querySelector(
+                    (el.dataset as { bsTarget: string }).bsTarget
+                );
+
+                if (target) {
+                    getCollapse(target).addTrigger(el);
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Return the existing Collapse instance associated with an element, or a new
+ * one if none exists. The WeakMap allows elements and instances to be
+ * discarded once they are removed from the dom and have no more references.
+ */
+const map = new WeakMap<HTMLElement, Collapse>();
+const getCollapse = getFromMap(map, (el) => new Collapse(el));
+
+function getFromMap<K extends object, V>(map: WeakMap<K, V>, create: (key: K) => V) {
+    return (key: K): V => {
+        if (!map.has(key)) {
+            map.set(key, create(key));
+        }
+
+        const value = map.get(key);
+        assert(value);
+
+        return value;
+    };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@
  * @preferred
  */
 
+import 'construct-style-sheets-polyfill';
 import assert from 'assert';
 
 import { DisplayMode, EnvironmentIndexer, Indexes } from './indexer';
@@ -43,8 +44,6 @@ import {
     addWarningHandler,
     getNextColor,
 } from './utils';
-
-require('./static/chemiscope.css');
 
 /**
  * Configuration for the [[DefaultVisualizer]]

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,6 +45,8 @@ import {
     getNextColor,
 } from './utils';
 
+import './static/chemiscope.css';
+
 /**
  * Configuration for the [[DefaultVisualizer]]
  */

--- a/src/map/map.ts
+++ b/src/map/map.ts
@@ -14,7 +14,7 @@ import { Property, Settings } from '../dataset';
 
 import { EnvironmentIndexer, Indexes } from '../indexer';
 import { OptionModificationOrigin } from '../options';
-import { GUID, PositioningCallback, arrayMaxMin, generateGUID, sendWarning } from '../utils';
+import { GUID, PositioningCallback, arrayMaxMin, sendWarning } from '../utils';
 import { enumerate, getElement, getFirstKey } from '../utils';
 
 import { MapData, NumericProperty } from './data';
@@ -258,7 +258,6 @@ export class PropertiesMap {
         this._root.style.setProperty('height', '100%');
         this._shadow.appendChild(this._root);
 
-
         if (this._root.style.position === '') {
             this._root.style.position = 'relative';
         }
@@ -270,15 +269,13 @@ export class PropertiesMap {
 
         this._data = new MapData(properties);
 
-        const guid = ('chsp-' + generateGUID()) as GUID;
         this._options = new MapOptions(
             this._root,
-            guid,
             this._data[this._indexer.mode],
             (rect) => this.positionSettingsModal(rect),
             config.settings
         );
-        this._colorReset = this.getById<HTMLButtonElement>(this._options.getId('map-color-reset'));
+        this._colorReset = this._options.getModalElement<HTMLButtonElement>('map-color-reset');
 
         this._connectSettings();
 
@@ -304,16 +301,16 @@ export class PropertiesMap {
         ];
     }
 
-    public getById<T extends HTMLElement = HTMLElement>(id: string): T {
-        return this._shadow.getElementById(id) as T;
-    }
-
     /**
      * Remove all HTML added by this [[PropertiesMap]] in the current document
      */
     public remove(): void {
-        this._root.innerHTML = '';
+        // Remove the the shadow root's host. It is not possible to remove the shadow root directly.
+        this._shadow.host.remove();
+
+        // Remove options
         this._options.remove();
+
         // remove SVG element created by Plotly
         document.getElementById('js-plotly-tester')?.remove();
 
@@ -1382,8 +1379,8 @@ export class PropertiesMap {
         if (axisBounds !== undefined) {
             // round to 10 decimal places so it does not break in Firefox
             const step = Math.round(((axisBounds[1] - axisBounds[0]) / 20) * 10 ** 10) / 10 ** 10;
-            const minElement = this.getById<HTMLInputElement>(this._options.getId(`map-${name}-min`));
-            const maxElement = this.getById<HTMLInputElement>(this._options.getId(`map-${name}-max`));
+            const minElement = this._options.getModalElement<HTMLInputElement>(`map-${name}-min`);
+            const maxElement = this._options.getModalElement<HTMLInputElement>(`map-${name}-max`);
             minElement.step = `${step}`;
             maxElement.step = `${step}`;
         }

--- a/src/map/options.ts
+++ b/src/map/options.ts
@@ -9,7 +9,7 @@ import { Settings } from '../dataset';
 import { HTMLOption, OptionsGroup } from '../options';
 import { optionValidator } from '../options';
 import { GUID, PositioningCallback } from '../utils';
-import { arrayMaxMin, getByID, makeDraggable, sendWarning } from '../utils';
+import { arrayMaxMin, makeDraggable, sendWarning } from '../utils';
 import { NumericProperties, NumericProperty } from './data';
 
 import { COLOR_MAPS } from './colorscales';
@@ -74,7 +74,7 @@ export class MapOptions extends OptionsGroup {
         reverse: HTMLOption<'boolean'>;
     };
 
-    /// The GUID of this set of options
+    // The GUID of this set of options
     private _guid: GUID;
     /// The HTML button to open the settings modal
     private _openModal: HTMLElement;
@@ -82,9 +82,11 @@ export class MapOptions extends OptionsGroup {
     private _modal: HTMLElement;
     // Callback to get the initial positioning of the settings modal.
     private _positionSettingsModal: PositioningCallback;
+    // Root node for the options
+    private _root: Node;
 
     constructor(
-        root: HTMLElement,
+        root: Node,
         guid: GUID,
         properties: NumericProperties,
         positionSettings: PositioningCallback,
@@ -104,6 +106,7 @@ export class MapOptions extends OptionsGroup {
         }
 
         this._guid = guid;
+        this._root = root;
 
         this.x = new AxisOptions(propertiesName);
         this.y = new AxisOptions(propertiesName);
@@ -154,10 +157,17 @@ export class MapOptions extends OptionsGroup {
         this._modal = modal;
         this._openModal = openModal;
         root.appendChild(this._openModal);
-        document.body.appendChild(this._modal);
+        root.getRootNode().appendChild(this._modal);
 
         this._bind(properties);
         this.applySettings(settings);
+    }
+
+    private _getById<T extends HTMLElement = HTMLElement>(id: string): T {
+        const shadow = this._root.getRootNode();
+        assert(shadow instanceof ShadowRoot);
+
+        return shadow.getElementById(id) as T;
     }
 
     /**
@@ -368,30 +378,30 @@ export class MapOptions extends OptionsGroup {
     /** Bind all options to the corresponding HTML elements */
     private _bind(properties: NumericProperties): void {
         // ======= data used as x values
-        const selectXProperty = getByID<HTMLSelectElement>(this.getId('map-x-property'));
+        const selectXProperty = this._getById<HTMLSelectElement>(this.getId('map-x-property'));
         selectXProperty.options.length = 0;
         for (const key in properties) {
             selectXProperty.options.add(new Option(key, key));
         }
         this.x.property.bind(selectXProperty, 'value');
-        this.x.min.bind(this.getId('map-x-min'), 'value');
-        this.x.max.bind(this.getId('map-x-max'), 'value');
-        this.x.scale.bind(this.getId('map-x-scale'), 'value');
+        this.x.min.bind(this._getById(this.getId('map-x-min')), 'value');
+        this.x.max.bind(this._getById(this.getId('map-x-max')), 'value');
+        this.x.scale.bind(this._getById(this.getId('map-x-scale')), 'value');
 
         // ======= data used as y values
-        const selectYProperty = getByID<HTMLSelectElement>(this.getId('map-y-property'));
+        const selectYProperty = this._getById<HTMLSelectElement>(this.getId('map-y-property'));
 
         selectYProperty.options.length = 0;
         for (const key in properties) {
             selectYProperty.options.add(new Option(key, key));
         }
         this.y.property.bind(selectYProperty, 'value');
-        this.y.min.bind(this.getId('map-y-min'), 'value');
-        this.y.max.bind(this.getId('map-y-max'), 'value');
-        this.y.scale.bind(this.getId('map-y-scale'), 'value');
+        this.y.min.bind(this._getById(this.getId('map-y-min')), 'value');
+        this.y.max.bind(this._getById(this.getId('map-y-max')), 'value');
+        this.y.scale.bind(this._getById(this.getId('map-y-scale')), 'value');
 
         // ======= data used as z values
-        const selectZProperty = getByID<HTMLSelectElement>(this.getId('map-z-property'));
+        const selectZProperty = this._getById<HTMLSelectElement>(this.getId('map-z-property'));
         // first option is 'none'
         selectZProperty.options.length = 0;
         selectZProperty.options.add(new Option('none', ''));
@@ -399,12 +409,14 @@ export class MapOptions extends OptionsGroup {
             selectZProperty.options.add(new Option(key, key));
         }
         this.z.property.bind(selectZProperty, 'value');
-        this.z.min.bind(this.getId('map-z-min'), 'value');
-        this.z.max.bind(this.getId('map-z-max'), 'value');
-        this.z.scale.bind(this.getId('map-z-scale'), 'value');
+        this.z.min.bind(this._getById(this.getId('map-z-min')), 'value');
+        this.z.max.bind(this._getById(this.getId('map-z-max')), 'value');
+        this.z.scale.bind(this._getById(this.getId('map-z-scale')), 'value');
 
         // ======= data used as color values
-        const selectColorProperty = getByID<HTMLSelectElement>(this.getId('map-color-property'));
+        const selectColorProperty = this._getById<HTMLSelectElement>(
+            this.getId('map-color-property')
+        );
         // first option is 'fixed'
         selectColorProperty.options.length = 0;
         selectColorProperty.options.add(new Option('fixed', ''));
@@ -412,11 +424,11 @@ export class MapOptions extends OptionsGroup {
             selectColorProperty.options.add(new Option(key, key));
         }
         this.color.property.bind(selectColorProperty, 'value');
-        this.color.min.bind(this.getId('map-color-min'), 'value');
-        this.color.max.bind(this.getId('map-color-max'), 'value');
+        this.color.min.bind(this._getById(this.getId('map-color-min')), 'value');
+        this.color.max.bind(this._getById(this.getId('map-color-max')), 'value');
 
         // ======= color palette
-        const selectPalette = getByID<HTMLSelectElement>(this.getId('map-color-palette'));
+        const selectPalette = this._getById<HTMLSelectElement>(this.getId('map-color-palette'));
         selectPalette.length = 0;
         for (const key in COLOR_MAPS) {
             selectPalette.options.add(new Option(key, key));
@@ -424,7 +436,9 @@ export class MapOptions extends OptionsGroup {
         this.palette.bind(selectPalette, 'value');
 
         // ======= marker symbols
-        const selectSymbolProperty = getByID<HTMLSelectElement>(this.getId('map-symbol-property'));
+        const selectSymbolProperty = this._getById<HTMLSelectElement>(
+            this.getId('map-symbol-property')
+        );
         // first option is 'fixed'
         selectSymbolProperty.options.length = 0;
         selectSymbolProperty.options.add(new Option('fixed', ''));
@@ -436,7 +450,9 @@ export class MapOptions extends OptionsGroup {
         this.symbol.bind(selectSymbolProperty, 'value');
 
         // ======= marker size
-        const selectSizeProperty = getByID<HTMLSelectElement>(this.getId('map-size-property'));
+        const selectSizeProperty = this._getById<HTMLSelectElement>(
+            this.getId('map-size-property')
+        );
         // first option is 'fixed'
         selectSizeProperty.options.length = 0;
         selectSizeProperty.options.add(new Option('fixed', ''));
@@ -444,9 +460,9 @@ export class MapOptions extends OptionsGroup {
             selectSizeProperty.options.add(new Option(key, key));
         }
         this.size.property.bind(selectSizeProperty, 'value');
-        this.size.factor.bind(this.getId('map-size-factor'), 'value');
-        this.size.mode.bind(this.getId('map-size-scale'), 'value');
-        this.size.reverse.bind(this.getId('map-size-reverse'), 'checked');
+        this.size.factor.bind(this._getById(this.getId('map-size-factor')), 'value');
+        this.size.mode.bind(this._getById(this.getId('map-size-scale')), 'value');
+        this.size.reverse.bind(this._getById(this.getId('map-size-reverse')), 'checked');
     }
 
     /** Get the colorscale to use for markers in the main plotly trace */
@@ -456,8 +472,8 @@ export class MapOptions extends OptionsGroup {
 
     /** Changes the min/max range label between linear and log appropriately */
     public setLogLabel(axis: AxisOptions, axisName: string): void {
-        const minInputLabel = getByID(this.getId(`map-${axisName}-min-label`));
-        const maxInputLabel = getByID(this.getId(`map-${axisName}-max-label`));
+        const minInputLabel = this._getById(this.getId(`map-${axisName}-min-label`));
+        const maxInputLabel = this._getById(this.getId(`map-${axisName}-max-label`));
 
         if (axis.scale.value === 'log') {
             minInputLabel.innerHTML = 'min: 10^';

--- a/src/map/plotly/fix-plot.ts
+++ b/src/map/plotly/fix-plot.ts
@@ -1,0 +1,133 @@
+import { PlotlyScatterElement } from './plotly-scatter';
+
+/**
+ * Fix a Plotly bug that causes incorrect mouse selection coordinates when
+ * creating 2d plots inside shadow roots. The function adds mouse event
+ * listeners to the plot and document and re-emits them with correct
+ * coordinates.
+
+ * Because some listeners are added to the document, they must be explicitly
+ * removed (using the returned object) when the plot is destroyed. The fix is
+ * automatically disabled when changing the plot to 3d, and enabled when
+ * initializing or going back to 2d.
+ *
+ * See [Plotly.js issue #6108](https://github.com/plotly/plotly.js/issues/6108)
+ * for details.
+ *
+ * @param plot The element to be fixed.
+ * @returns A { disable, enable } object to toggle the fix.
+ */
+export default function fixPlot(plot: PlotlyScatterElement) {
+    let movement: {
+        data: {
+            buttons: number;
+            clientX: number;
+            clientY: number;
+            ctrlKey: boolean;
+        };
+        target: EventTarget;
+    } | null = null;
+
+    const mousedownListener = (event: MouseEvent) => {
+        if (event.isTrusted && event.target) {
+            event.preventDefault();
+            event.stopPropagation();
+
+            // Store the event data. The event will be re-remited later on
+            // as we cannot yet determine whether the coordinates need to be
+            // corrected (if the user selected a point) or not (if the user
+            // selected an area for zooming).
+            movement = {
+                data: {
+                    buttons: event.buttons,
+                    clientX: event.clientX,
+                    clientY: event.clientY,
+                    ctrlKey: event.ctrlKey,
+                },
+                target: event.target,
+            };
+        }
+    };
+
+    const mouseupListener = (event: MouseEvent) => {
+        if (movement && event.target) {
+            event.preventDefault();
+            event.stopImmediatePropagation();
+
+            // 'composed' is necessary for the event to behave correctly
+            // in a shadow root.
+            const downEvent = new Event('mousedown', { composed: true });
+            Object.assign(downEvent, {
+                ...movement.data,
+                // The correction is applied here and was determined empirically.
+                clientX: movement.data.clientX - 50,
+                clientY: movement.data.clientY - 50,
+            });
+
+            const target = movement.target;
+            movement = null;
+            target.dispatchEvent(downEvent);
+
+            const upEvent = new Event('mouseup', { bubbles: true, composed: true });
+            event.target.dispatchEvent(upEvent);
+        }
+    };
+
+    const mousemoveListener = (event: MouseEvent) => {
+        if (movement) {
+            event.preventDefault();
+            event.stopImmediatePropagation();
+
+            // Additional logic to allow area selection, in which case the bug
+            // doesn't happen and no fix is needed.
+            if (
+                Math.abs(event.clientX - movement.data.clientX) > 5 ||
+                Math.abs(event.clientY - movement.data.clientY) > 5
+            ) {
+                const downEvent = new Event('mousedown', { composed: true });
+                Object.assign(downEvent, movement.data);
+
+                const target = movement.target;
+                movement = null;
+                target.dispatchEvent(downEvent);
+            }
+        }
+    };
+
+    let enabled = false;
+
+    const enable = () => {
+        enabled = true;
+
+        plot.addEventListener('mousedown', mousedownListener, { capture: true });
+        document.addEventListener('mouseup', mouseupListener);
+        document.addEventListener('mousemove', mousemoveListener);
+    };
+
+    const disable = () => {
+        enabled = false;
+
+        plot.removeEventListener('mousedown', mousedownListener, { capture: true });
+        document.removeEventListener('mouseup', mouseupListener);
+        document.removeEventListener('mousemove', mousemoveListener);
+    };
+
+    // Toggle the fix when the plot type changes.
+    plot.on('plotly_restyle', ([update]) => {
+        if ('type' in update) {
+            if (enabled && update.type === 'scatter3d') {
+                disable();
+            }
+            if (!enabled && update.type === 'scattergl') {
+                enable();
+            }
+        }
+    });
+
+    // Enable the fix if the plot is 2d.
+    if (plot._fullData[0].type === 'scattergl') {
+        enable();
+    }
+
+    return { disable, enable };
+}

--- a/src/map/plotly/plotly-scatter.d.ts
+++ b/src/map/plotly/plotly-scatter.d.ts
@@ -7,6 +7,10 @@ interface ScatterAxis extends LayoutAxis {
 }
 
 interface ScatterLayout {
+    _modeBar: {
+        _uid: string;
+    };
+
     xaxis: ScatterAxis;
     yaxis: ScatterAxis;
     scene: {
@@ -19,5 +23,8 @@ interface ScatterLayout {
 }
 
 export interface PlotlyScatterElement extends PlotlyHTMLElement {
+    _fullData: {
+        type: 'scatter3d' | 'scattergl';
+    }[];
     _fullLayout: ScatterLayout;
 }

--- a/src/map/plotly/plotly-styles.ts
+++ b/src/map/plotly/plotly-styles.ts
@@ -10,7 +10,7 @@ declare global {
 }
 
 export function getPlotStyleSheet(plot: PlotlyScatterElement): CSSStyleSheet {
-  return getStyleSheet(plot._fullLayout._modeBar._uid);
+    return getStyleSheet(plot._fullLayout._modeBar._uid);
 }
 
 export const globalStyleSheet = getStyleSheet('global');
@@ -18,20 +18,19 @@ export const globalStyleSheet = getStyleSheet('global');
 document.adoptedStyleSheets = [...document.adoptedStyleSheets, getDocumentStyleSheet()];
 
 function getStyleSheet(name: string): CSSStyleSheet {
-  const style = document.getElementById(`plotly.js-style-${name}`);
-  assert(style instanceof HTMLStyleElement);
-  assert(style.sheet);
+    const style = document.getElementById(`plotly.js-style-${name}`);
+    assert(style instanceof HTMLStyleElement);
+    assert(style.sheet);
 
+    const sheet = new CSSStyleSheet();
 
-  const sheet = new CSSStyleSheet();
+    for (const rule of Array.from(style.sheet.cssRules)) {
+        sheet.insertRule(rule.cssText);
+    }
 
-  for (const rule of Array.from(style.sheet.cssRules)) {
-    sheet.insertRule(rule.cssText);
-  }
+    style.remove();
 
-  style.remove();
-
-  return sheet;
+    return sheet;
 }
 
 // Only keep the rules regarding .plotly-notifier which is a direct child of <body>.

--- a/src/map/plotly/plotly-styles.ts
+++ b/src/map/plotly/plotly-styles.ts
@@ -1,0 +1,48 @@
+import assert from 'assert';
+
+import './plotly-scatter'; // Necessary for Plotly to add a <style> element
+import type { PlotlyScatterElement } from './plotly-scatter';
+
+declare global {
+    interface CSSRule {
+        selectorText: string;
+    }
+}
+
+export function getPlotStyleSheet(plot: PlotlyScatterElement): CSSStyleSheet {
+  return getStyleSheet(plot._fullLayout._modeBar._uid);
+}
+
+export const globalStyleSheet = getStyleSheet('global');
+
+document.adoptedStyleSheets = [...document.adoptedStyleSheets, getDocumentStyleSheet()];
+
+function getStyleSheet(name: string): CSSStyleSheet {
+  const style = document.getElementById(`plotly.js-style-${name}`);
+  assert(style instanceof HTMLStyleElement);
+  assert(style.sheet);
+
+
+  const sheet = new CSSStyleSheet();
+
+  for (const rule of Array.from(style.sheet.cssRules)) {
+    sheet.insertRule(rule.cssText);
+  }
+
+  style.remove();
+
+  return sheet;
+}
+
+// Only keep the rules regarding .plotly-notifier which is a direct child of <body>.
+function getDocumentStyleSheet(): CSSStyleSheet {
+    const sheet = new CSSStyleSheet();
+
+    for (const rule of Array.from(globalStyleSheet.cssRules)) {
+        if (rule.selectorText.startsWith('.plotly-notifier')) {
+            sheet.insertRule(rule.cssText);
+        }
+    }
+
+    return sheet;
+}

--- a/src/map/plotly/plotly-styles.ts
+++ b/src/map/plotly/plotly-styles.ts
@@ -24,7 +24,7 @@ function getStyleSheet(name: string): CSSStyleSheet {
 
     const sheet = new CSSStyleSheet();
 
-    for (const rule of Array.from(style.sheet.cssRules)) {
+    for (const rule of style.sheet.cssRules) {
         sheet.insertRule(rule.cssText);
     }
 
@@ -37,7 +37,7 @@ function getStyleSheet(name: string): CSSStyleSheet {
 function getDocumentStyleSheet(): CSSStyleSheet {
     const sheet = new CSSStyleSheet();
 
-    for (const rule of Array.from(globalStyleSheet.cssRules)) {
+    for (const rule of globalStyleSheet.cssRules) {
         if (rule.selectorText.startsWith('.plotly-notifier')) {
             sheet.insertRule(rule.cssText);
         }

--- a/src/modal.ts
+++ b/src/modal.ts
@@ -55,7 +55,7 @@ export default class Modal {
         });
 
         // Find close buttons inside the modal.
-        for (const el of Array.from(this._element.querySelectorAll('[data-bs-dismiss="modal"]'))) {
+        for (const el of this._element.querySelectorAll('[data-bs-dismiss="modal"]')) {
             el.addEventListener('click', () => {
                 this.close();
             });

--- a/src/modal.ts
+++ b/src/modal.ts
@@ -1,0 +1,141 @@
+/**
+ * Component for managing modals, with two main roles: apply classes (and
+ * eventually add/remove from the dom) to the modal and its backdrop at the
+ * right time, and listen for events causing the modal to close (e.g. clicking
+ * on the backdrop).
+ *
+ * The classes and styles applied match those used by Bootstrap. They are
+ * summarized in this table:
+ *               | Modal         | Backdrop                  |
+ *  Closed       | display: none | <removed>                 |
+ *  Closing      | -             | .modal-backdrop.fade      |
+ *  Open/Opening | .show         | .modal-backdrop.fade.show |
+ * More classes must be set by the user for correct styling, such as .modal for
+ * the modal. See [the Bootstrap docs](https://getbootstrap.com/docs/5.2/components/modal/)
+ * for details.
+ *
+ * The modal is inserted in the body and is contained inside a shadow
+ * root. It can be styled as follows:
+ *  modal.shadow.adoptedStyleSheets = [...]
+ *
+ * When the modal is closed, the focus, if any, is restored to the element that
+ * was focused prior to opening the modal.
+ */
+export default class Modal {
+    private _activeElement: Element | null = null;
+    private _backdrop: HTMLElement;
+    private _open = false;
+
+    public shadow: ShadowRoot;
+
+    /**
+     * Create a Modal instance.
+     * @param _element The root element to use as a modal. It should have the
+     *  .modal class.
+     */
+    constructor(private _element: HTMLElement) {
+        // Create a shadow root in the body to hold the modal.
+        const hostElement = document.createElement('div');
+        document.body.appendChild(hostElement);
+
+        this.shadow = hostElement.attachShadow({ mode: 'open' });
+        this.shadow.appendChild(this._element);
+
+        // Initialize the backdrop element. It will be inserted and removed from
+        // the DOM following the modal's lifecycle.
+        this._backdrop = document.createElement('div');
+        this._backdrop.classList.add('modal-backdrop', 'fade');
+
+        // Listen for click events on the root element (excluding its children),
+        // which corresponds to the backdrop.
+        this._element.addEventListener('click', (event) => {
+            if (event.target === event.currentTarget) {
+                this.close();
+            }
+        });
+
+        // Find close buttons inside the modal.
+        for (const el of Array.from(this._element.querySelectorAll('[data-bs-dismiss="modal"]'))) {
+            el.addEventListener('click', () => {
+                this.close();
+            });
+        }
+
+        // Listen for Escape key presses.
+        document.addEventListener('keydown', (event) => {
+            if (event.key === 'Escape') {
+                event.preventDefault();
+                this.close();
+            }
+        });
+
+        // Listeners called once the modal is closed
+
+        this._element.addEventListener('transitionend', (event) => {
+            if (event.target === event.currentTarget && !this._open) {
+                this._element.style.setProperty('display', 'none');
+            }
+        });
+
+        this._backdrop.addEventListener('transitionend', () => {
+            if (!this._open) {
+                this._backdrop.remove();
+
+                if (this._activeElement && this._activeElement instanceof HTMLElement) {
+                    this._activeElement.focus();
+                }
+
+                this._activeElement = null;
+            }
+        });
+    }
+
+    close(): void {
+        this._backdrop.classList.remove('show');
+        this._element.classList.remove('show');
+        this._open = false;
+    }
+
+    open(): void {
+        this._element.getRootNode().appendChild(this._backdrop);
+        this._element.style.setProperty('display', 'block');
+
+        // Trick to allow transitioning immediately after setting display to block
+        // eslint-disable-next-line no-unused-expressions
+        this._element.offsetHeight;
+
+        this._backdrop.classList.add('show');
+        this._element.classList.add('show');
+
+        // Unfocus the active element and store it in order to focus it again
+        // once the modal is closed.
+        this._activeElement = getActiveElement();
+
+        if (this._activeElement && this._activeElement instanceof HTMLElement) {
+            this._activeElement.blur();
+        }
+
+        this._open = true;
+    }
+
+    toggle(value: boolean = !this.open): void {
+        if (value) {
+            this.open();
+        } else {
+            this.close();
+        }
+    }
+
+    remove(): void {
+        this.shadow.host.remove();
+    }
+}
+
+// Returns the active element in `root`, if any, no matter how nested it is in
+// shadow roots. When reaching a closed shadow root containing that element,
+// the function will return the root's host element.
+function getActiveElement(root: DocumentOrShadowRoot = document): Element | null {
+    const activeElement = root.activeElement;
+
+    return activeElement?.shadowRoot ? getActiveElement(activeElement.shadowRoot) : activeElement;
+}

--- a/src/structure/widget.ts
+++ b/src/structure/widget.ts
@@ -239,9 +239,9 @@ export class MoleculeViewer {
         this._root.addEventListener(
             'wheel',
             (event) => {
-                // Avoid an infinite loop by only intercepting the original event
-                // and not synthetic ones.
-                if (event instanceof WheelEvent) {
+                // Avoid an infinite loop by only intercepting the original
+                // (= trusted) event and not synthetic ones.
+                if (event.isTrusted) {
                     event.preventDefault();
                     event.stopImmediatePropagation();
 

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -1,0 +1,10 @@
+// These CSS imports return CSSStyleSheet objects for them to be manually
+// "adopted" by shadow roots, unlike the default css-loader configuration
+// which injects the CSS to the page's <head> element. The inline import syntax
+// of Webpack is used here to avoid conflicts with the Jupyter Notebook build
+// configuration.
+
+import bootstrap from '!css-loader?exportType=css-style-sheet!bootstrap/dist/css/bootstrap.min.css';
+import chemiscope from '!css-loader?exportType=css-style-sheet!./static/chemiscope.css';
+
+export { bootstrap, chemiscope };

--- a/src/typing.d.ts
+++ b/src/typing.d.ts
@@ -7,3 +7,10 @@ declare module '*.svg' {
     const content: string;
     export default content;
 }
+
+declare module '*.css';
+
+declare module '*.css?sheet' {
+    const content: CSSStyleSheet;
+    export default content;
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -58,12 +58,15 @@ export function generateGUID(): GUID {
  *
  * @throws if there is not element with the given id.
  */
-export function getByID<HTMLType = HTMLElement>(id: string, root?: HTMLElement): HTMLType {
+export function getByID<HTMLType = HTMLElement>(
+    id: string,
+    root: Document | HTMLElement | ShadowRoot = document
+): HTMLType {
     let e;
-    if (root !== undefined) {
+    if (root instanceof HTMLElement) {
         e = root.querySelector(`#${id}`);
     } else {
-        e = document.getElementById(id);
+        e = root.getElementById(id);
     }
     if (e === null) {
         throw Error(`unable to get element with id ${id}`);

--- a/tests/helper.test.ts
+++ b/tests/helper.test.ts
@@ -1,0 +1,1 @@
+import 'construct-style-sheets-polyfill';

--- a/tests/map/map.test.ts
+++ b/tests/map/map.test.ts
@@ -59,8 +59,8 @@ describe('Map', () => {
         // default is to have a constant color)
         options.color.property.value = 'first';
 
-        const minSelectElement = options.getById<HTMLSelectElement>(options.getId(`map-color-min`));
-        const maxSelectElement = options.getById<HTMLSelectElement>(options.getId(`map-color-max`));
+        const minSelectElement = options.getModalElement<HTMLSelectElement>(`map-color-min`);
+        const maxSelectElement = options.getModalElement<HTMLSelectElement>(`map-color-max`);
         const originalMin = options.color.min.value;
         const originalMax = options.color.max.value;
 

--- a/tests/map/map.test.ts
+++ b/tests/map/map.test.ts
@@ -2,7 +2,7 @@ import { PropertiesMap } from '../../src/map';
 import { MarkerData } from '../../src/map/marker';
 import { EnvironmentIndexer } from '../../src/indexer';
 import { Property } from '../../src/dataset';
-import { GUID, getByID } from '../../src/utils';
+import { GUID } from '../../src/utils';
 
 import { assert } from 'chai';
 
@@ -28,14 +28,6 @@ const DUMMY_STRUCTURES = [
         z: [0, 1],
     },
 ];
-
-async function waitForUpdate(): Promise<void> {
-    await new Promise<void>((resolve) => {
-        setTimeout(() => {
-            resolve();
-        }, 0);
-    });
-}
 
 describe('Map', () => {
     before(() => {
@@ -67,8 +59,8 @@ describe('Map', () => {
         // default is to have a constant color)
         options.color.property.value = 'first';
 
-        const minSelectElement = getByID<HTMLSelectElement>(options.getId(`map-color-min`));
-        const maxSelectElement = getByID<HTMLSelectElement>(options.getId(`map-color-max`));
+        const minSelectElement = options.getById<HTMLSelectElement>(options.getId(`map-color-min`));
+        const maxSelectElement = options.getById<HTMLSelectElement>(options.getId(`map-color-max`));
         const originalMin = options.color.min.value;
         const originalMax = options.color.max.value;
 
@@ -141,49 +133,5 @@ describe('map markers', () => {
         MAP.removeMarker(secondGUID);
         assert(MAP['_selected'].size === 0);
         assert(MAP['_active'] === undefined);
-    });
-
-    it('can change the point associated with a marker', async () => {
-        MAP.addMarker(firstGUID, 'red', { structure: 0, environment: 0 });
-        assert(getMarker(firstGUID).current === 0);
-        const initialPosition = getMarker(firstGUID).marker.getBoundingClientRect();
-
-        MAP.select({ structure: 1, environment: 1 });
-        assert(getMarker(firstGUID).current === 1);
-        let position = getMarker(firstGUID).marker.getBoundingClientRect();
-
-        assert(position.x !== initialPosition.x);
-        assert(position.y !== initialPosition.y);
-
-        MAP.select({ structure: 0, environment: 0 });
-        assert(getMarker(firstGUID).current === 0);
-        position = getMarker(firstGUID).marker.getBoundingClientRect();
-
-        assert(position.x === initialPosition.x);
-        assert(position.y === initialPosition.y);
-
-        // Check that the marker position in 2D mode accounts for the scale of
-        // the axis. In 3D mode this is always the case since we use plotly to
-        // render the markers.
-        MAP['_options'].x.scale.value = 'log';
-
-        // Wait for the marker's position to be updated. Although the marker's
-        // update is synchronous in regards to getBoundingClientRect(),
-        // it is only triggered once Plotly is done rendering, which is an
-        // asynchronous operation.
-        await waitForUpdate();
-
-        position = getMarker(firstGUID).marker.getBoundingClientRect();
-        assert(position.x !== initialPosition.x);
-        assert(position.y === initialPosition.y);
-
-        MAP['_options'].x.scale.value = 'linear';
-        MAP['_options'].y.scale.value = 'log';
-
-        await waitForUpdate();
-
-        position = getMarker(firstGUID).marker.getBoundingClientRect();
-        assert(position.x === initialPosition.x);
-        assert(position.y !== initialPosition.y);
     });
 });

--- a/tests/map/options.test.ts
+++ b/tests/map/options.test.ts
@@ -1,5 +1,4 @@
 import { AxisOptions, MapOptions } from '../../src/map/options';
-import { GUID } from '../../src/utils';
 
 import { assert } from 'chai';
 
@@ -52,7 +51,6 @@ describe('MapOptions', () => {
         const root = createShadow();
         const options = new MapOptions(
             root,
-            'this-is-my-id' as GUID,
             DUMMY_PROPERTIES,
             DUMMY_CALLBACK
         );
@@ -65,14 +63,13 @@ describe('MapOptions', () => {
 
     it('scale label for min/max switches between linear and log', () => {
         const root = createShadow();
-        const guid = 'guid' as GUID;
 
-        const options = new MapOptions(root, guid, DUMMY_PROPERTIES, DUMMY_CALLBACK);
+        const options = new MapOptions(root, DUMMY_PROPERTIES, DUMMY_CALLBACK);
 
         function checkScaleLabel(axisOptions: AxisOptions, axisName: string): void {
-            const min = options.getById(`guid-map-${axisName}-min-label`);
-            const max = options.getById(`guid-map-${axisName}-max-label`);
-            const selectElement = options.getById<HTMLSelectElement>(`guid-map-${axisName}-scale`);
+            const min = options.getModalElement(`map-${axisName}-min-label`);
+            const max = options.getModalElement(`map-${axisName}-max-label`);
+            const selectElement = options.getModalElement<HTMLSelectElement>(`map-${axisName}-scale`);
 
             // change from linear (default) to log scale
             selectElement.value = 'log';
@@ -96,27 +93,12 @@ describe('MapOptions', () => {
         options.remove();
     });
 
-    it('has a unique id in the page', () => {
-        const root = createShadow();
-
-        const guid = 'this-is-my-id' as GUID;
-        const options = new MapOptions(root, guid, DUMMY_PROPERTIES, DUMMY_CALLBACK);
-        traverseDOM(root, (element) => {
-            if (element.id) {
-                assert(element.id.includes(guid));
-            }
-        });
-
-        options.remove();
-    });
-
     it('axis property changes when modified by the user', () => {
         const root = createShadow();
-        const guid = 'guid' as GUID;
-        const options = new MapOptions(root, guid, DUMMY_PROPERTIES, DUMMY_CALLBACK);
+        const options = new MapOptions(root, DUMMY_PROPERTIES, DUMMY_CALLBACK);
 
         function checkPropertySelect(axisOptions: AxisOptions, axisName: string) {
-            const selectElement = options.getById<HTMLSelectElement>(`guid-map-${axisName}-property`);
+            const selectElement = options.getModalElement<HTMLSelectElement>(`map-${axisName}-property`);
             selectElement.value = 'first';
             selectElement.dispatchEvent(new window.Event('change'));
             assert(selectElement.value !== 'second');
@@ -136,12 +118,11 @@ describe('MapOptions', () => {
 
     it('axis range changes when min/max are modified', () => {
         const root = createShadow();
-        const guid = 'guid' as GUID;
-        const options = new MapOptions(root, guid, DUMMY_PROPERTIES, DUMMY_CALLBACK);
+        const options = new MapOptions(root, DUMMY_PROPERTIES, DUMMY_CALLBACK);
 
         function checkRangeSelect(axisOptions: AxisOptions, axisName: string) {
-            const minSelectElement = options.getById<HTMLSelectElement>(`guid-map-${axisName}-min`);
-            const maxSelectElement = options.getById<HTMLSelectElement>(`guid-map-${axisName}-max`);
+            const minSelectElement = options.getModalElement<HTMLSelectElement>(`map-${axisName}-min`);
+            const maxSelectElement = options.getModalElement<HTMLSelectElement>(`map-${axisName}-max`);
 
             assert(minSelectElement.value !== '0.01');
             assert(axisOptions.min.value !== 0.01);
@@ -167,9 +148,8 @@ describe('MapOptions', () => {
     it('property used for size changes when modified by the user', () => {
         const root = createShadow();
 
-        const guid = 'guid' as GUID;
-        const options = new MapOptions(root, guid, DUMMY_PROPERTIES, DUMMY_CALLBACK);
-        const selectElement = options.getById<HTMLSelectElement>(`guid-map-size-property`);
+        const options = new MapOptions(root, DUMMY_PROPERTIES, DUMMY_CALLBACK);
+        const selectElement = options.getModalElement<HTMLSelectElement>('map-size-property');
 
         assert(selectElement.value !== 'second');
         assert(options.size.property.value !== 'second');
@@ -182,9 +162,8 @@ describe('MapOptions', () => {
 
     it('size factor changes when the slider is modified by the user', () => {
         const root = createShadow();
-        const guid = 'guid' as GUID;
-        const options = new MapOptions(root, guid, DUMMY_PROPERTIES, DUMMY_CALLBACK);
-        const sliderElement = options.getById<HTMLInputElement>(`guid-map-size-factor`);
+        const options = new MapOptions(root, DUMMY_PROPERTIES, DUMMY_CALLBACK);
+        const sliderElement = options.getModalElement<HTMLInputElement>('map-size-factor');
 
         assert(sliderElement.value !== '100');
         assert(options.size.factor.value !== 100);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,8 +7,7 @@
     "declarationDir": "dist/",
     "downlevelIteration": true,
     "sourceMap": true,
-    "lib": ["dom", "es5"],
-
+    "lib": ["dom", "dom.iterable", "es5"],
     "skipLibCheck": true /* Skip type checking of declaration files */
   },
   "typedocOptions": {


### PR DESCRIPTION
Main changes:

- The whole map component is in a shadow root, with the options modal as a child of the root.
- Bootstrap and Chemiscope's CSS are loaded using constructed style sheets, loaded using a Webpack resource query `?sheet` and [polyfilled](https://github.com/calebdwilliams/construct-style-sheets) on browsers that don't support it (i.e. all except Blink browsers).
- Other CSS files are loaded normally using ES6 imports.
- Plotly's `<style>` elements are removed from the `<head>` and transformed into a constructed style sheet adopted by the corresponding shadow root.
- Bootstrap's collapse and modal logic is rewritten, but still uses Bootstrap's classes (e.g. .modal) and attributes (e.g. data-bs-target).

Questions/tasks that remain:

- Should the polyfill be added on the package or the app? I think in the package is ok since it's quite small (5 kB), perfectly replicates the spec and wouldn't cause problems if included twice.
- Adding `dom.iterable` to `compilerOptions.lib` in the typescript config would avoid useless `Array.from()` calls in `for (let el of Array.from(document.querySelectorAll(...))) { ... }`. Is there any argument against this?
- Move Bootstrap replacement files in a specific directory, something like `components`? I think the name components would be better for referring to map and structure, so feel free to propose something else.
- It would be nice for the user to be able to create a map not only by providing an element but also by receiving one. This would allow embedding in tools such as [Observable](https://observablehq.com/) where the user can return an element at the end of a code block to be displayed. For example we could give the shadow root's host as `map.element` instead of asking for its parent in the map's constructor.
- I have opened an issue regarding Plotly's bug: plotly/plotly.js#6108. In the meantime I have created a hack that intercepts mousedown and mouseup events to fix the issue ~(not in the PR yet)~.
- ~I need to update the tests as well.~

Let me know what you think.
