### PR TITLE
Remove highlighted environement when loading a new structure

### DIFF
--- a/src/structure/widget.ts
+++ b/src/structure/widget.ts
@@ -363,6 +363,10 @@ export class MoleculeViewer {
                 this._viewer.removeLabel(label);
             }
         }
+        if (this._highlighted !== undefined) {
+            this._viewer.removeModel(this._highlighted.model);
+            this._highlighted = undefined;
+        }
 
         // load new structure
         this._current = {


### PR DESCRIPTION
Otherwise, due to a bad interaction between #166 and #217 the code would crash trying to access the previous cutoff (in the old structure) when loading a new structure.