### PR TITLE
Styling tweaks to the app to leave more vertical space to the panels

### DIFF
--- a/app/app.css
+++ b/app/app.css
@@ -4,15 +4,15 @@ html {
 }
 
 body {
-    margin-bottom: 60px;
+    margin-bottom: 35px;
 }
 
 .footer {
     position: absolute;
     bottom: 0;
     width: 100%;
-    height: 60px;
-    padding-top: 20px;
+    height: 40px;
+    padding-top: 12px;
     background-color: #2c3e50;
     color: white;
     font-size: 0.8rem;
@@ -30,7 +30,7 @@ body {
 header {
     background-color: #2c3e50;
     width: 100%;
-    height: 60px;
+    height: 40px;
 }
 
 .navbar {
@@ -55,20 +55,20 @@ header {
 }
 
 main.container-fluid {
-    margin: 1.5em 0em calc(1.5em + 60px) 0em;
+    margin: 1.5em 0em calc(1.5em + 40px) 0em;
     width: 100%;
 }
 
 @media screen and (min-width: 1200px) {
     main.container-fluid {
-        margin: 2em 2em calc(2em + 60px) 2em;
+        margin: 2em 2em calc(2em + 40px) 2em;
         width: calc(100% - 4em);
     }
 }
 
 @media screen and (min-width: 1500px) {
     main.container-fluid {
-        margin: 2em auto calc(2em + 60px) auto;
+        margin: 2em auto calc(2em + 40px) auto;
         width: 1500px;
     }
 }
@@ -92,12 +92,12 @@ main .ratio > * {
 
 @media screen and (min-width: 768px) {
     .ratio-5x7 {
-        max-height: calc(100vh - 4em - 120px);
+        max-height: calc(100vh - 2em - 80px);
     }
 
     main .ratio {
         /* set the width to fit the vertical space, and the height will be set automatically */
-        max-width: calc(100vh - 4em - 120px);
+        max-width: calc(100vh - 2em - 80px);
     }
 }
 

--- a/app/app.css
+++ b/app/app.css
@@ -1,3 +1,8 @@
+:root {
+    --header-height: 50px;
+    --footer-height: 40px;
+}
+
 html {
     position: relative;
     min-height: 100%;
@@ -11,7 +16,7 @@ body {
     position: absolute;
     bottom: 0;
     width: 100%;
-    height: 40px;
+    height: var(--footer-height);
     padding-top: 12px;
     background-color: #2c3e50;
     color: white;
@@ -30,7 +35,7 @@ body {
 header {
     background-color: #2c3e50;
     width: 100%;
-    height: 40px;
+    height: var(--header-height);
 }
 
 .navbar {
@@ -55,20 +60,20 @@ header {
 }
 
 main.container-fluid {
-    margin: 1.5em 0em calc(1.5em + 40px) 0em;
+    margin: 1.5em 0em calc(1.5em + var(--header-height)) 0em;
     width: 100%;
 }
 
 @media screen and (min-width: 1200px) {
     main.container-fluid {
-        margin: 2em 2em calc(2em + 40px) 2em;
+        margin: 2em 2em calc(2em + var(--header-height)) 2em;
         width: calc(100% - 4em);
     }
 }
 
 @media screen and (min-width: 1500px) {
     main.container-fluid {
-        margin: 2em auto calc(2em + 40px) auto;
+        margin: 2em auto calc(2em + var(--header-height)) auto;
         width: 1500px;
     }
 }
@@ -92,12 +97,12 @@ main .ratio > * {
 
 @media screen and (min-width: 768px) {
     .ratio-5x7 {
-        max-height: calc(100vh - 2em - 80px);
+        max-height: calc(100vh - 2em - var(--header-height) - var(--footer-height));
     }
 
     main .ratio {
         /* set the width to fit the vertical space, and the height will be set automatically */
-        max-width: calc(100vh - 2em - 80px);
+        max-width: calc(100vh - 2em - var(--header-height) - var(--footer-height));
     }
 }
 

--- a/app/app.ts
+++ b/app/app.ts
@@ -45,14 +45,14 @@ export class ChemiscopeApp {
         const root = getByID(id);
         root.innerHTML = `<div class="container-fluid">
             <div class="row">
-                <div class="col-md-7" style="padding: 0">
+                <div class="col-md-6" style="padding: 0">
                     <div class="ratio ratio-1x1">
                         <div id="chemiscope-meta"></div>
                         <div id="chemiscope-map" style="position: absolute"></div>
                     </div>
                 </div>
 
-                <div class="col-md-5" style="padding: 0">
+                <div class="col-md-6" style="padding: 0">
                     <div class="ratio ratio-5x7">
                         <div>
                             <!-- height: 0 below is a hack to force safari to

--- a/app/index.html
+++ b/app/index.html
@@ -29,7 +29,7 @@
 
     <body>
         <header>
-            <nav class="container navbar navbar-expand-lg navbar-dark py-0">
+            <nav class="container navbar navbar-expand-lg navbar-dark py-1">
                 <div class="container-fluid">
                     <a class="navbar-brand" href="#">chemiscope</a>
                     <button
@@ -94,7 +94,7 @@
             </nav>
         </header>
 
-        <div class="container" style="height:1em; padding:0">
+        <div class="container" style="height: 1em; padding: 0">
             <div class="alert alert-dismissible alert-danger pop-on-top" role="alert" id="error-display" style="display: none">
                 <button
                     type="button"
@@ -131,11 +131,9 @@
             <div class="container">
                 <div style="float: left; font-size: x-small">Created by <a href="https://guillaume.fraux.fr">Guillaume Fraux</a></div>
                 <div style="float: right; font-size: x-small">
-                    <i class="far fa-copyright"></i> 2021 <a href="https://cosmo.epfl.ch">COSMO@EPFL</a> 
-&nbsp; - &nbsp;
-                    <span id="chemiscope-version"
-                        >unknown version</span
-                    >
+                    <i class="far fa-copyright"></i> 2021 <a href="https://cosmo.epfl.ch">COSMO@EPFL</a>
+                    &nbsp; - &nbsp;
+                    <span id="chemiscope-version">unknown version</span>
                 </div>
                 <div style="text-align: center">Chemiscope: interactive structure/property explorer for materials and molecules</div>
             </div>

--- a/app/index.html
+++ b/app/index.html
@@ -29,7 +29,7 @@
 
     <body>
         <header>
-            <nav class="container navbar navbar-expand-lg navbar-dark">
+            <nav class="container navbar navbar-expand-lg navbar-dark py-0">
                 <div class="container-fluid">
                     <a class="navbar-brand" href="#">chemiscope</a>
                     <button
@@ -94,7 +94,7 @@
             </nav>
         </header>
 
-        <div class="container">
+        <div class="container" style="height:1em; padding:0">
             <div class="alert alert-dismissible alert-danger pop-on-top" role="alert" id="error-display" style="display: none">
                 <button
                     type="button"
@@ -131,7 +131,9 @@
             <div class="container">
                 <div style="float: left; font-size: x-small">Created by <a href="https://guillaume.fraux.fr">Guillaume Fraux</a></div>
                 <div style="float: right; font-size: x-small">
-                    <i class="far fa-copyright"></i> 2021 <a href="https://cosmo.epfl.ch">COSMO@EPFL</a> <br /><span id="chemiscope-version"
+                    <i class="far fa-copyright"></i> 2021 <a href="https://cosmo.epfl.ch">COSMO@EPFL</a> 
+&nbsp; - &nbsp;
+                    <span id="chemiscope-version"
                         >unknown version</span
                     >
                 </div>


### PR DESCRIPTION
The style of the web app wastes (IMO) a lot of vertical space. When on a laptop, this makes the panels really too small and crammed. I made a few tweaks to the CSS that give a bit more space to the panels when on a smallish screen. Probably same result could be achieved with better CSS magic, but I leave these tweaks to the experts....