### PR TITLE
Fix several issues in map tests

### DIFF
--- a/karma.conf.ts
+++ b/karma.conf.ts
@@ -42,10 +42,10 @@ WEBPACK_CONFIG.plugins?.push(new RemoveDeclarationsFromAssets());
 
 module.exports = (config: Config) => {
     config.set({
-        browserNoActivityTimeout: 8000,
+        browserNoActivityTimeout: 32000,
         client: {
             mocha: {
-                timeout: 8000,
+                timeout: 32000,
             },
         },
 

--- a/tests/map/map.test.ts
+++ b/tests/map/map.test.ts
@@ -29,11 +29,11 @@ const DUMMY_STRUCTURES = [
     },
 ];
 
-async function wait(duration: number = 0): Promise<void> {
+async function waitForUpdate(): Promise<void> {
     await new Promise<void>((resolve) => {
         setTimeout(() => {
             resolve();
-        }, duration);
+        }, 0);
     });
 }
 
@@ -167,9 +167,11 @@ describe('map markers', () => {
         // render the markers.
         MAP['_options'].x.scale.value = 'log';
 
-        // Use setTimeout with a timeout of 0 to let Plotly re-render and
-        // then trigger an update of the marker before checking its position
-        await wait();
+        // Wait for the marker's position to be updated. Although the marker's
+        // update is synchronous in regards to getBoundingClientRect(),
+        // it is only triggered once Plotly is done rendering, which is an
+        // asynchronous operation.
+        await waitForUpdate();
 
         position = getMarker(firstGUID).marker.getBoundingClientRect();
         assert(position.x !== initialPosition.x);
@@ -178,7 +180,7 @@ describe('map markers', () => {
         MAP['_options'].x.scale.value = 'linear';
         MAP['_options'].y.scale.value = 'log';
 
-        await wait();
+        await waitForUpdate();
 
         position = getMarker(firstGUID).marker.getBoundingClientRect();
         assert(position.x === initialPosition.x);

--- a/tests/map/map.test.ts
+++ b/tests/map/map.test.ts
@@ -11,11 +11,11 @@ let KARMA_INSERTED_HTML: string;
 const DUMMY_PROPERTIES = {
     first: {
         target: 'structure',
-        values: [1.1, 1.2],
+        values: [1.1, 1.2, 0.6],
     } as Property,
     second: {
         target: 'structure',
-        values: [2.1, 2.2],
+        values: [2.1, 2.2, 1.4],
     } as Property,
 };
 
@@ -28,6 +28,14 @@ const DUMMY_STRUCTURES = [
         z: [0, 1],
     },
 ];
+
+async function wait(duration: number = 0): Promise<void> {
+    await new Promise<void>((resolve) => {
+        setTimeout(() => {
+            resolve();
+        }, duration);
+    });
+}
 
 describe('Map', () => {
     before(() => {
@@ -135,7 +143,7 @@ describe('map markers', () => {
         assert(MAP['_active'] === undefined);
     });
 
-    it('can change the point associated with a marker', () => {
+    it('can change the point associated with a marker', async () => {
         MAP.addMarker(firstGUID, 'red', { structure: 0, environment: 0 });
         assert(getMarker(firstGUID).current === 0);
         const initialPosition = getMarker(firstGUID).marker.getBoundingClientRect();
@@ -159,20 +167,21 @@ describe('map markers', () => {
         // render the markers.
         MAP['_options'].x.scale.value = 'log';
 
-        // use setTimeout with a timeout of 0 to allow the browser to re-render
-        // the marker before checking its position
-        setTimeout(() => {
-            position = getMarker(firstGUID).marker.getBoundingClientRect();
-            assert(position.x !== initialPosition.x);
-            assert(position.y === initialPosition.y);
-        }, 0);
+        // Use setTimeout with a timeout of 0 to let Plotly re-render and
+        // then trigger an update of the marker before checking its position
+        await wait();
+
+        position = getMarker(firstGUID).marker.getBoundingClientRect();
+        assert(position.x !== initialPosition.x);
+        assert(position.y === initialPosition.y);
 
         MAP['_options'].x.scale.value = 'linear';
         MAP['_options'].y.scale.value = 'log';
-        setTimeout(() => {
-            position = getMarker(firstGUID).marker.getBoundingClientRect();
-            assert(position.x !== initialPosition.x);
-            assert(position.y !== initialPosition.y);
-        }, 0);
+
+        await wait();
+
+        position = getMarker(firstGUID).marker.getBoundingClientRect();
+        assert(position.x === initialPosition.x);
+        assert(position.y !== initialPosition.y);
     });
 });


### PR DESCRIPTION
This PR aims to fix 2-3 problems in `map.test.ts`:

1. The reliance on `setTimeout` without [calling `done()`](https://mochajs.org/#asynchronous-code) or returning a promise caused undefined behavior from Mocha; sometimes half of the tests weren't running. See [here](https://github.com/lab-cosmo/chemiscope/runs/5157249353) for example, it says `Executed 13 of 27 SUCCESS`.
2. The `setTimeout` calls should be one after the other instead of at the same time. I've rewritten the code with promises.
3. The test was failing anyway because there were only two points on the plot so they were always at the same position (at the border of the plot) no matter the scale. I have added a third point to fix that.

I have also taken the liberty of increasing test timeouts as they were otherwise failing on my computer (opening 6 browsers at the same time makes it a little slow). I think it's fine since none of the tests rely on timing, but let me know if you don't like it.