### PR TITLE
Simple fix to allow for non-bonding species in 3dmol

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.9]
+        python-version: ['3.7', '3.10']
     steps:
       - uses: actions/checkout@v2
         # we need the full history to be able to get the chemiscope version with
@@ -51,16 +51,16 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install "tox>=4.0.0a8"
+          pip install "tox>=4.0.0b2"
       - name: Run Python tests
-        run: tox4
+        run: tox
 
   # Python linting
   python-lint:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.9]
+        python-version: ['3.10']
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}

--- a/src/structure/3dmol/assignBonds.ts
+++ b/src/structure/3dmol/assignBonds.ts
@@ -87,6 +87,7 @@ function bondLength(elem: string): number {
 // return true if atom1 and atom2 are probably bonded to each other
 // based on distance alone
 function areConnected(atom1: AtomSpec, atom2: AtomSpec) {
+    if (atom1.elem === 'X' || atom2.elem === 'X') return false;
     let maxsq = bondLength(atom1.elem) + bondLength(atom2.elem);
     maxsq += 0.25; // fudge factor, especially important for md frames, also see 1i3d
     maxsq *= maxsq;


### PR DESCRIPTION
Allows users to designate non-bonding items as type 'X', which is typically reserved for generalized entities in ase without known bonding nature (so it's appropriate)