### PR TITLE
Isolate the metadata panel

### DIFF
--- a/app/app.ts
+++ b/app/app.ts
@@ -47,7 +47,7 @@ export class ChemiscopeApp {
             <div class="row">
                 <div class="col-md-6" style="padding: 0">
                     <div class="ratio ratio-1x1">
-                        <div id="chemiscope-meta"></div>
+                        <div id="chemiscope-meta" style="z-index: 10"></div>
                         <div id="chemiscope-map" style="position: absolute"></div>
                     </div>
                 </div>

--- a/python/nbextension/src/index.ts
+++ b/python/nbextension/src/index.ts
@@ -13,6 +13,5 @@
 
 export * from './widget';
 
-
 // Prevent Chemiscope's Bootstrap v5 from replacing Jupyter's Bootstrap v3.
 (window as any).$.fn.modal.noConflict();

--- a/src/map/options.ts
+++ b/src/map/options.ts
@@ -306,10 +306,7 @@ export class MapOptions extends OptionsGroup {
         // replace id to ensure they are unique even if we have multiple viewers
         // on a single page
         // prettier-ignore
-        template.innerHTML = HTML_OPTIONS
-            .replace(/id="(.*?)"/g, (_: string, id: string) => `id="${id}"`)
-            .replace(/for="(.*?)"/g, (_: string, id: string) => `for="${id}"`)
-            .replace(/data-bs-target="#(.*?)"/g, (_: string, id: string) => `data-bs-target="#${id}"`);
+        template.innerHTML = HTML_OPTIONS;
 
         const modalElement = template.content.querySelector('.modal');
         assert(modalElement !== null && modalElement instanceof HTMLElement);

--- a/src/structure/grid.ts
+++ b/src/structure/grid.ts
@@ -695,10 +695,7 @@ export class ViewersGrid {
 
             // add a new widget if necessary
             if (!this._viewers.has(cellGUID)) {
-                const widget = new MoleculeViewer(
-                    this._getById<HTMLElement>(`gi-${cellGUID}`),
-                    cellGUID
-                );
+                const widget = new MoleculeViewer(this._getById<HTMLElement>(`gi-${cellGUID}`));
 
                 widget.onselect = (atom: number) => {
                     if (this._indexer.mode !== 'atom' || this._active !== cellGUID) {
@@ -729,9 +726,8 @@ export class ViewersGrid {
                 const current = { atom: undefined, structure: -1, environment: -1 };
 
                 // get the 'delay' setting inside the current widget setting
-                const playbackDelay = widget._options.getModalElement<HTMLInputElement>(
-                    `chsp-${cellGUID}-playback-delay`
-                );
+                const playbackDelay =
+                    widget._options.getModalElement<HTMLInputElement>('playback-delay');
 
                 this._viewers.set(cellGUID, {
                     color: color,

--- a/src/structure/options.ts
+++ b/src/structure/options.ts
@@ -10,7 +10,7 @@ import Modal from '../modal';
 import { Settings } from '../dataset';
 import { HTMLOption, OptionsGroup } from '../options';
 import { optionValidator } from '../options';
-import { GUID, PositioningCallback, getByID, makeDraggable, sendWarning } from '../utils';
+import { PositioningCallback, getByID, makeDraggable, sendWarning } from '../utils';
 
 import BARS_SVG from '../static/bars.svg';
 import HTML_OPTIONS from './options.html';
@@ -53,7 +53,7 @@ export class StructureOptions extends OptionsGroup {
     // Callback to get the initial positioning of the settings modal.
     private _positionSettingsModal: PositioningCallback;
 
-    constructor(root: HTMLElement, guid: GUID, positionSettings: PositioningCallback) {
+    constructor(root: HTMLElement, positionSettings: PositioningCallback) {
         super();
 
         this.bonds = new HTMLOption('boolean', true);
@@ -105,7 +105,7 @@ export class StructureOptions extends OptionsGroup {
 
         this._positionSettingsModal = positionSettings;
 
-        const { openModal, modal } = this._createSettingsHTML(guid);
+        const { openModal, modal } = this._createSettingsHTML();
         this._modal = modal;
         this._modal.shadow.adoptedStyleSheets = (
             root.getRootNode() as ShadowRoot
@@ -113,7 +113,7 @@ export class StructureOptions extends OptionsGroup {
         this._openModal = openModal;
         root.appendChild(this._openModal);
 
-        this._bind(guid);
+        this._bind();
     }
 
     /** Get in a element in the modal from its id */
@@ -153,31 +153,19 @@ export class StructureOptions extends OptionsGroup {
      *
      * The HTML elements are returned, not yet inserted in the document.
      *
-     * @param  root where to place the HTML button
-     * @param  guid unique identifier of the corresponding MoleculeViewer, used
-     *              as prefix for all HTML elements `id`
-     * @return      the HTML element containing the setting modal
+     * @return the HTML element containing the setting modal, and the button to open the modal
      */
-    private _createSettingsHTML(guid: GUID): { modal: Modal; openModal: HTMLElement } {
+    private _createSettingsHTML(): { modal: Modal; openModal: HTMLElement } {
         // use HTML5 template to generate a DOM object from an HTML string
         const template = document.createElement('template');
         template.innerHTML = `<button
             class="btn btn-light btn-sm chsp-viewer-button"
-            data-bs-target="#${guid}-structure-settings"
-            data-bs-toggle="modal"
             style="top: 4px; right: 4px; opacity: 1;">
                 <div>${BARS_SVG}</div>
             </button>`;
         const openModal = template.content.firstChild as HTMLElement;
 
-        // replace id to ensure they are unique even if we have multiple viewers
-        // on a single page
-        // prettier-ignore
-        template.innerHTML = HTML_OPTIONS
-            .replace(/id="(.*?)"/g, (_: string, id: string) => `id="${guid}-${id}"`)
-            .replace(/for="(.*?)"/g, (_: string, id: string) => `for="${guid}-${id}"`)
-            .replace(/data-bs-target="#(.*?)"/g, (_: string, id: string) => `data-bs-target="#${guid}-${id}"`);
-
+        template.innerHTML = HTML_OPTIONS;
         const modalElement = template.content.querySelector('.modal');
         assert(modalElement !== null && modalElement instanceof HTMLElement);
         const modalDialog = modalElement.querySelector('.modal-dialog');
@@ -223,25 +211,25 @@ export class StructureOptions extends OptionsGroup {
     }
 
     /** Bind all options to the corresponding HTML elements */
-    private _bind(guid: GUID): void {
-        this.atomLabels.bind(this.getModalElement(`${guid}-atom-labels`), 'checked');
-        this.spaceFilling.bind(this.getModalElement(`${guid}-space-filling`), 'checked');
-        this.bonds.bind(this.getModalElement(`${guid}-bonds`), 'checked');
+    private _bind(): void {
+        this.atomLabels.bind(this.getModalElement('atom-labels'), 'checked');
+        this.spaceFilling.bind(this.getModalElement('space-filling'), 'checked');
+        this.bonds.bind(this.getModalElement('bonds'), 'checked');
 
-        this.rotation.bind(this.getModalElement(`${guid}-rotation`), 'checked');
-        this.unitCell.bind(this.getModalElement(`${guid}-unit-cell`), 'checked');
+        this.rotation.bind(this.getModalElement('rotation'), 'checked');
+        this.unitCell.bind(this.getModalElement('unit-cell'), 'checked');
 
-        this.supercell[0].bind(this.getModalElement(`${guid}-supercell-a`), 'value');
-        this.supercell[1].bind(this.getModalElement(`${guid}-supercell-b`), 'value');
-        this.supercell[2].bind(this.getModalElement(`${guid}-supercell-c`), 'value');
+        this.supercell[0].bind(this.getModalElement('supercell-a'), 'value');
+        this.supercell[1].bind(this.getModalElement('supercell-b'), 'value');
+        this.supercell[2].bind(this.getModalElement('supercell-c'), 'value');
 
-        this.axes.bind(this.getModalElement(`${guid}-axes`), 'value');
-        this.keepOrientation.bind(this.getModalElement(`${guid}-keep-orientation`), 'checked');
+        this.axes.bind(this.getModalElement('axes'), 'value');
+        this.keepOrientation.bind(this.getModalElement('keep-orientation'), 'checked');
 
-        this.environments.activated.bind(this.getModalElement(`${guid}-env-activated`), 'checked');
-        this.environments.bgColor.bind(this.getModalElement(`${guid}-env-bg-color`), 'value');
-        this.environments.bgStyle.bind(this.getModalElement(`${guid}-env-bg-style`), 'value');
-        this.environments.cutoff.bind(this.getModalElement(`${guid}-env-cutoff`), 'value');
-        this.environments.center.bind(this.getModalElement(`${guid}-env-center`), 'checked');
+        this.environments.activated.bind(this.getModalElement('env-activated'), 'checked');
+        this.environments.bgColor.bind(this.getModalElement('env-bg-color'), 'value');
+        this.environments.bgStyle.bind(this.getModalElement('env-bg-style'), 'value');
+        this.environments.cutoff.bind(this.getModalElement('env-cutoff'), 'value');
+        this.environments.center.bind(this.getModalElement('env-center'), 'checked');
     }
 }

--- a/tests/structure/options.test.ts
+++ b/tests/structure/options.test.ts
@@ -1,5 +1,4 @@
 import { StructureOptions } from '../../src/structure/options';
-import { GUID } from '../../src/utils';
 
 import { assert } from 'chai';
 
@@ -17,16 +16,6 @@ function createShadowChild(): HTMLElement {
     return element;
 }
 
-function traverseDOM(element: Element, callback: (element: Element) => void) {
-    if (element.children) {
-        const elements = element.children;
-        for (let i = 0; i < elements.length; i++) {
-            traverseDOM(elements[i], callback);
-        }
-    }
-    callback(element);
-}
-
 let KARMA_INSERTED_HTML: string;
 
 describe('StructureOptions', () => {
@@ -38,26 +27,12 @@ describe('StructureOptions', () => {
     it('can remove itself from DOM', () => {
         const root = createShadowChild();
 
-        const options = new StructureOptions(root, 'this-is-my-id' as GUID, DUMMY_CALLBACK);
+        const options = new StructureOptions(root, DUMMY_CALLBACK);
         assert(root.innerHTML !== '');
         assert(document.body.innerHTML !== KARMA_INSERTED_HTML);
 
         options.remove();
         assert(document.body.innerHTML === KARMA_INSERTED_HTML);
         assert(root.innerHTML === '');
-    });
-
-    it('has a unique id in the page', () => {
-        const root = createShadowChild();
-
-        const guid = 'this-is-my-id' as GUID;
-        const options = new StructureOptions(root, guid, DUMMY_CALLBACK);
-        traverseDOM(document.body, (element) => {
-            if (element.id) {
-                assert(element.id.includes(guid));
-            }
-        });
-
-        options.remove();
     });
 });


### PR DESCRIPTION
This PR contains two commits: the first one removes the guid from the structure viewer (as far as I understand, it is no longer required since everything moved to a shadow root, and different roots can have the same id inside); and the second moves the metadata panel to a shadow root.

@slietar would you have some time to review this?