### PR TITLE
Only run cron job for Collab notebook check once a week

### DIFF
--- a/.github/workflows/colab.yml
+++ b/.github/workflows/colab.yml
@@ -1,7 +1,8 @@
 name: Check Colab Notebook
 on:
   schedule:
-    - cron: '* * 1 * *'
+    # run at 10am on every Monday
+    - cron: '0 10 * * 1'
   pull_request:
     # Check all PR
 


### PR DESCRIPTION
The previous cron meant "run every minute on the first day of the month", and with github rate limiting this is running every 5 min today: https://github.com/lab-cosmo/chemiscope/actions/workflows/colab.yml