### PR TITLE
Changed structure viewer to use playback delay as a savable option

### DIFF
--- a/src/structure/grid.ts
+++ b/src/structure/grid.ts
@@ -64,8 +64,6 @@ interface WidgetGridData {
     color: string;
     /// set of indexes currently displayed in this viewer
     current: Indexes;
-    /// Playback delay setting for this viewer
-    playbackDelay: HTMLInputElement;
 }
 
 /**
@@ -340,7 +338,6 @@ export class ViewersGrid {
 
         const current = this._viewers.get(this._active);
         assert(current !== undefined);
-        current.playbackDelay.onchange = () => {};
 
         // remove active classes from the previous active viewer
         changeClasses(this._active, false);
@@ -349,11 +346,14 @@ export class ViewersGrid {
 
         const newViewer = this._viewers.get(this._active);
         assert(newViewer !== undefined);
-        newViewer.playbackDelay.onchange = () => {
-            this.delayChanged(parseFloat(newViewer.playbackDelay.value) * 100);
-        };
+
+        // links playback delay options
+        newViewer.widget._options.playbackDelay.onchange.push((value) => {
+            this.delayChanged(value);
+        });
+
         // set the right initial value for playback delay
-        this.delayChanged(parseFloat(newViewer.playbackDelay.value) * 100);
+        this.delayChanged(newViewer.widget._options.playbackDelay.value);
 
         changeClasses(this._active, true);
     }
@@ -725,15 +725,10 @@ export class ViewersGrid {
 
                 const current = { atom: undefined, structure: -1, environment: -1 };
 
-                // get the 'delay' setting inside the current widget setting
-                const playbackDelay =
-                    widget._options.getModalElement<HTMLInputElement>('playback-delay');
-
                 this._viewers.set(cellGUID, {
                     color: color,
                     current: current,
                     widget: widget,
-                    playbackDelay: playbackDelay,
                 });
 
                 if (this._positionSettingsModal !== undefined) {

--- a/src/structure/options.html.in
+++ b/src/structure/options.html.in
@@ -137,10 +137,10 @@
                         <h5 class="chsp-settings-section-title">Trajectory</h5>
                         <div class="chsp-settings-trajectory">
                             <div class="input-group input-group-sm">
-                                <label class="input-group-text" for="playback-delay" title="playback delay in tenths of seconds" style="cursor: help">
+                                <label class="input-group-text" for="playback-delay" title="playback delay in milliseconds" style="cursor: help">
                                     playback delay
                                 </label>
-                                <input id="playback-delay" class="form-control" type="number" min="1" value="7" />
+                                <input id="playback-delay" class="form-control" type="number" min="100" value="700" step="100" />
                             </div>
                             <div class="form-check form-switch">
                                 <input type="checkbox" class="form-check-input" id="keep-orientation" />

--- a/src/structure/options.ts
+++ b/src/structure/options.ts
@@ -32,6 +32,8 @@ export class StructureOptions extends OptionsGroup {
     public axes: HTMLOption<'string'>;
     // keep the orientation constant when loading a new structure
     public keepOrientation: HTMLOption<'boolean'>;
+    // trajectory playback delay in seconds
+    public playbackDelay: HTMLOption<'number'>;
     // options related to environments
     public environments: {
         // should we display environments & environments options
@@ -80,6 +82,7 @@ export class StructureOptions extends OptionsGroup {
         this.axes = new HTMLOption('string', 'off');
         this.axes.validate = optionValidator(['off', 'abc', 'xyz'], 'axes');
         this.keepOrientation = new HTMLOption('boolean', false);
+        this.playbackDelay = new HTMLOption('number', 700);
 
         this.environments = {
             activated: new HTMLOption('boolean', true),
@@ -144,7 +147,6 @@ export class StructureOptions extends OptionsGroup {
             }
             delete settings.packedCell;
         }
-
         super.applySettings(settings);
     }
 
@@ -225,6 +227,7 @@ export class StructureOptions extends OptionsGroup {
 
         this.axes.bind(this.getModalElement('axes'), 'value');
         this.keepOrientation.bind(this.getModalElement('keep-orientation'), 'checked');
+        this.playbackDelay.bind(this.getModalElement('playback-delay'), 'value');
 
         this.environments.activated.bind(this.getModalElement('env-activated'), 'checked');
         this.environments.bgColor.bind(this.getModalElement('env-bg-color'), 'value');


### PR DESCRIPTION
It's nice to be able to set (and save) the playback delay, which was impossible because it was not part of the structure options. This adds a playbackDelay option that is saved in the dataset json, and is accessible from Python as well, and removes some (IMO) unnecessary special handling of playbackDelay inside ViewersGrid. 

Also, moves from using tens of second to milliseconds as units, which seems more natural. 