### PR TITLE
Considering the pyodide_kernel interpreter in the _is_running_in_notebook

### DIFF
--- a/python/chemiscope/jupyter.py
+++ b/python/chemiscope/jupyter.py
@@ -194,7 +194,9 @@ def _is_running_in_notebook():
 
     try:
         shell = get_ipython().__class__.__name__
-        if shell == "ZMQInteractiveShell":
+        # ZMQInteractiveShell is the standard Jupyter Kernel
+        # Interpreter is used by pyiodide
+        if shell in ["ZMQInteractiveShell", "Interpreter"]:
             return True
         elif shell == "TerminalInteractiveShell":
             return False


### PR DESCRIPTION
jupyterlite is using pyodide_kernel interpreter to run python code in the browser, we add this so chemiscope can be  run within jupyterlite


From jupyterlite
![image](https://user-images.githubusercontent.com/2772557/235427768-6fe24747-a49c-4c55-a7ce-c2bbc0bc98cd.png)
try out https://agoscinski.github.io/jupyterlite-playground/lab/index.html (adding example currently, might need 20 minutes till it is on the homepage) EDIT: okay works now, use the cosmo.ipynb

I added this change to the code and it worked out for me
