### PR TITLE
Display a warning when using chemiscope.show inside a sphinx-gallery example

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,14 +22,17 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
+
       - name: configure access to git repositories in package-lock.json
         run: git config --global url."https://github.com/".insteadOf ssh://git@github.com
-      - name: update npm
-        run: npm install -g npm
+
       - name: install npm dependencies
         run: npm ci
+
       - run: npm run build
+
       - run: sudo apt-get install xvfb
+
       # use xvfb to run the tests with a pseudo-display attached
       # so that the browsers started by karma think there is a screen
       - run: xvfb-run --auto-servernum npm test

--- a/python/chemiscope/jupyter.py
+++ b/python/chemiscope/jupyter.py
@@ -35,7 +35,8 @@ class ChemiscopeWidgetBase(ipywidgets.DOMWidget, ipywidgets.ValueWidget):
 
         self.value = json.dumps(data)
         self.has_metadata = has_metadata
-        self.settings = data["settings"]
+        if "settings" in data:
+            self.settings = data["settings"]
         self._settings_sync = True
 
     def save(self, path):

--- a/python/chemiscope/jupyter.py
+++ b/python/chemiscope/jupyter.py
@@ -8,6 +8,8 @@ from traitlets import Bool, Dict, Unicode
 from .input import create_input
 from .version import __version__
 
+import warnings
+
 # this needs to match the version/name defined in
 # python/jupyter/src/labextension.ts
 PACKAGE_NAME = "chemiscope"
@@ -55,6 +57,16 @@ class ChemiscopeWidgetBase(ipywidgets.DOMWidget, ipywidgets.ValueWidget):
 
         file.write(json.dumps(data).encode("utf8"))
         file.close()
+
+    def _repr_html_(self):
+        if not _is_running_in_notebook():
+            return """
+    <div style="width: 100%; background-color: #f8d7da; color: #721c24;  border: 1px solid #f5c6cb; padding: 15px; font-size: 16px; box-sizing: border-box; text-align: center;">
+        Interactive chemiscope widgets can only be visualized inside a jupyter notebook.
+    </div>
+            """
+        else:
+            return self.__repr__()
 
 
 @ipywidgets.register
@@ -131,7 +143,7 @@ def show(
     .. _ase.Atoms: https://wiki.fysik.dtu.dk/ase/ase/atoms.html
     """
     if not _is_running_in_notebook():
-        raise Exception("chemiscope.show only works inside a jupyter notebook")
+        warnings.warn("chemiscope.show only works inside a jupyter notebook")
 
     has_metadata = meta is not None
     if not has_metadata:


### PR DESCRIPTION
chemiscope.show() won't crash when processed by sphinx-gallery, just issue a warning. 

Also, returns an HTML error message to be displayed e.g. by sphinx-gallery

A stop-gap solution to allow including chemiscope in example noteboox while we see how to implement #276 