### PR TITLE
Fixed input of arrow parameters

### DIFF
--- a/python/chemiscope/input.py
+++ b/python/chemiscope/input.py
@@ -224,9 +224,9 @@ def create_input(
         # "kind" : "arrow"
         {   # "orientation" is redundant and hence ignored
             "vector" : [float, float, float],  # orientation and shape of the arrow
-            "base_radius" : float,
-            "head_radius" : float,
-            "head_length" : float,   # the tip of the arrow is at the end of the segment. it'll extend past the base point if the arrow is not long enough
+            "baseRadius" : float,
+            "headRadius" : float,
+            "headLength" : float,   # the tip of the arrow is at the end of the segment. it'll extend past the base point if the arrow is not long enough
         }
 
         # "kind" : "custom"
@@ -980,17 +980,17 @@ def _check_valid_shape(shape):
                     "'simplices' must be an Nx3 array values for 'custom' shape kind"
                 )
     elif shape["kind"] == "arrow":
-        if not isinstance(parameters["base_radius"], float):
+        if not isinstance(parameters["baseRadius"], float):
             raise TypeError(
-                f"sphere shape 'base_radius' must be a float, got {type(parameters['radius'])}"
+                f"sphere shape 'baseRadius' must be a float, got {type(parameters['baseRadius'])}"
             )
-        if not isinstance(parameters["head_radius"], float):
+        if not isinstance(parameters["headRadius"], float):
             raise TypeError(
-                f"sphere shape 'head_radius' must be a float, got {type(parameters['radius'])}"
+                f"sphere shape 'headRadius' must be a float, got {type(parameters['headRadius'])}"
             )
-        if not isinstance(parameters["head_length"], float):
+        if not isinstance(parameters["headLength"], float):
             raise TypeError(
-                f"sphere shape 'head_length' must be a float, got {type(parameters['radius'])}"
+                f"sphere shape 'headLength' must be a float, got {type(parameters['headLength'])}"
             )
 
         vector_array = np.asarray(parameters["vector"]).astype(

--- a/python/chemiscope/structures/_ase.py
+++ b/python/chemiscope/structures/_ase.py
@@ -341,7 +341,7 @@ def ase_vectors_to_arrows(frames, key="forces", target=None, **kwargs):
     Extract a vectorial atom property from a list of ase.Atoms
     objects, and returns a list of arrow shapes. Besides the specific
     parameters it also accepts the same parameters as
-    `array_from_vector`, which are used to define the style of the
+    `arrow_from_vector`, which are used to define the style of the
     arrows.
 
     :param frames: list of ASE Atoms objects
@@ -357,15 +357,11 @@ def ase_vectors_to_arrows(frames, key="forces", target=None, **kwargs):
     # set shape parameters globally if they are all given
     globs = {}
     if "radius" in kwargs:
-        globs["base_radius"] = kwargs.pop("radius")
+        globs["baseRadius"] = kwargs.pop("radius")
         if "head_radius_scale" in kwargs:
-            globs["head_radius"] = globs["base_radius"] * kwargs.pop(
-                "head_radius_scale"
-            )
+            globs["headRadius"] = globs["baseRadius"] * kwargs.pop("head_radius_scale")
         if "head_length_scale" in kwargs:
-            globs["head_length"] = globs["base_radius"] * kwargs.pop(
-                "head_length_scale"
-            )
+            globs["headLength"] = globs["baseRadius"] * kwargs.pop("head_length_scale")
 
     for f in frames:
         values, target = _extract_key_from_ase(f, key, target)

--- a/python/chemiscope/structures/_shapes.py
+++ b/python/chemiscope/structures/_shapes.py
@@ -66,11 +66,11 @@ def arrow_from_vector(
 
     data = {"vector": [v * scale for v in vec]}
     if radius is not None:
-        data["base_radius"] = radius
+        data["baseRadius"] = radius
     if head_radius_scale is not None:
-        data["head_radius"] = radius * head_radius_scale
+        data["headRadius"] = radius * head_radius_scale
     if head_length_scale is not None:
-        data["head_length"] = radius * head_length_scale
+        data["headLength"] = radius * head_length_scale
 
     return data
 

--- a/python/examples/shapes.py
+++ b/python/examples/shapes.py
@@ -173,9 +173,9 @@ dipoles_manual = (
         kind="arrow",
         parameters={
             "global": {
-                "base_radius": 0.2,
-                "head_radius": 0.3,
-                "head_length": 0.5,
+                "baseRadius": 0.2,
+                "headRadius": 0.3,
+                "headLength": 0.5,
                 "color": 0xFF00B0,
             },
             "structure": [
@@ -189,9 +189,9 @@ dipoles_manual = (
 dipoles_auto = chemiscope.ase_vectors_to_arrows(frames, "dipole_ccsd", scale=0.5)
 # one can always update the defaults created by these automatic functions
 dipoles_auto["parameters"]["global"] = {
-    "base_radius": 0.2,
-    "head_radius": 0.3,
-    "head_length": 0.5,
+    "baseRadius": 0.2,
+    "headRadius": 0.3,
+    "headLength": 0.5,
     "color": 0xFF00B0,
 }
 


### PR DESCRIPTION
Turns out that renaming parameters for arrows from `underscore_names` to `jsCase` left quite a few bugs behind. Should all be fixed now. 