### PR TITLE
chemiscope-input had been lost due to removal of setup.cfg

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,9 @@ homepage = "https://chemiscope.org"
 documentation = "https://chemiscope.org/docs/"
 repository = "https://github.com/lab-cosmo/chemiscope"
 
+[project.scripts]
+chemiscope-input = "chemiscope.main:main"
+
 ### ======================================================================== ###
 
 [build-system]


### PR DESCRIPTION
We may say that the fact nobody noticed for a year means we should drop the tool altogether, but I think it makes sense to have it just for the old-school people who like the CLI. 

This simply adds it back to setup.py