### PR TITLE
Fix a bug in atom-centered shape layout

### DIFF
--- a/src/dataset.ts
+++ b/src/dataset.ts
@@ -350,6 +350,9 @@ function checkShapes(
     structureCount: number,
     envCount: number
 ): string {
+    // checks only that the shape and naming of shape options is correct.
+    // validity of the actual options is assessed in assignShapes
+
     if (typeof shapes !== 'object' || shapes === null) {
         return "'shapes' must be an object";
     }
@@ -415,7 +418,10 @@ function assignShapes(
     shapes: { [name: string]: ShapeParameters },
     structures: Structure[]
 ): string {
-    // creates shapes associated with actual structures by combining all the information given in the definition
+    // creates shapes associated with actual structures by picking slices of the full
+    // arrays. it also tests the shape validity, and for that it builds (but does not store)
+    // the fully expanded parameters for each shape
+
     let atomsCount = 0;
     for (let i_structure = 0; i_structure < structures.length; i_structure++) {
         const structure = structures[i_structure];

--- a/src/structure/viewer.ts
+++ b/src/structure/viewer.ts
@@ -1184,10 +1184,14 @@ export class MoleculeViewer {
                                     structure.y[i],
                                     structure.z[i],
                                 ];
-                                if (atom_pars.position) {
-                                    position = atom_pars.position;
+
+                                // only overrides the atom position if it's given explicitly
+                                const atom_position = current_shape.parameters.atom[i].position;
+                                if (atom_position !== undefined) {
+                                    position = atom_position;
                                 }
 
+                                // adds supercell offset
                                 position[0] += a * cell[0] + b * cell[3] + c * cell[6];
                                 position[1] += a * cell[1] + b * cell[4] + c * cell[7];
                                 position[2] += a * cell[2] + b * cell[5] + c * cell[8];

--- a/src/structure/viewer.ts
+++ b/src/structure/viewer.ts
@@ -17,7 +17,6 @@ import { Arrow, CustomShape, Cylinder, Ellipsoid, ShapeData, Sphere, add_shapes 
 import { StructureOptions } from './options';
 
 import { COLOR_MAPS } from '../map/colorscales';
-import { sensitiveHeaders } from 'http2';
 
 const IS_SAFARI =
     navigator.vendor !== undefined &&


### PR DESCRIPTION
Somehow this slipped through the cracks. Arrows (and any atom-centered shape) 
were positioned at the origin rather than at the atomic sites. 

Just to upset @rosecers I also included a few unrelated changes to avoid datafile bloat,
and to make her happy I added some extra comments to the shape code. 