### PR TITLE
Pinning ASE version

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -25,7 +25,7 @@ commands =
 [testenv:tests]
 description = Run Python unit tests
 deps =
-    ase
+    ase==3.22.1
 
 commands =
     python -m unittest discover -p "*.py" -s python/tests


### PR DESCRIPTION
Fix the version of ASE to avoid breaking all our examples.
We'll have to do something later, but for the moment I'd do this so we can keep working on everything else. 