### PR TITLE
Fix paths for the chemiscope spinx on the website

### DIFF
--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -56,7 +56,7 @@ html_sidebars = {"**": ["sidebar-toc.html", "searchbox.html"]}
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = [os.path.join("..", "_static")]
 html_favicon = "../_static/chemiscope-icon.png"
-html_baseurl = "docs/"
+html_baseurl = "doc"
 
 templates_path = [os.path.join("..", "_templates")]
 

--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -56,6 +56,7 @@ html_sidebars = {"**": ["sidebar-toc.html", "searchbox.html"]}
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = [os.path.join("..", "_static")]
 html_favicon = "../_static/chemiscope-icon.png"
+html_baseurl = "docs/"
 
 templates_path = [os.path.join("..", "_templates")]
 

--- a/python/chemiscope/sphinx/directive.py
+++ b/python/chemiscope/sphinx/directive.py
@@ -47,10 +47,23 @@ class ChemiscopeDirective(Directive):
             build_file_path, rel_file_path = self.get_build_file_path(filename)
             copy_file(rst_file_path, build_file_path)
 
+            # Get the path from the conf.py
+            config = self.state.document.settings.env.app.config
+
+            # html_baseurl is specified in the conf, let sphinx manage the path himself
+            if config.html_baseurl is not None:
+                html_baseurl = ""
+                rel_file_path = os.path.join(config.html_baseurl, rel_file_path)
+
+            # No parameter specified -> use root
+            else:
+                html_baseurl = "/"
+
             # Create the chemiscope node
             node = self.create_node(
                 rel_file_path,
                 include_headers=source not in ChemiscopeDirective.pages_with_headers,
+                html_baseurl=html_baseurl,
             )
 
             # indicates that the page has already been added headers
@@ -82,7 +95,7 @@ class ChemiscopeDirective(Directive):
 
         return build_file_path, rel_file_path
 
-    def create_node(self, rel_file_path, include_headers=True):
+    def create_node(self, rel_file_path, include_headers=True, html_baseurl=""):
         """
         Create a chemiscope node with the specified file path and mode
 
@@ -97,6 +110,7 @@ class ChemiscopeDirective(Directive):
         node["filepath"] = rel_file_path
         node["mode"] = self.options.get("mode", "default")
         node["include_headers"] = include_headers
+        node["html_baseurl"] = html_baseurl
 
         self.state.nested_parse(self.content, self.content_offset, node)
 

--- a/python/chemiscope/sphinx/nodes.py
+++ b/python/chemiscope/sphinx/nodes.py
@@ -21,7 +21,12 @@ def depart_chemiscope_latex(self, node):
 
 def visit_chemiscope_html(self, node):
     self.body.append(
-        generate_html_content(node["filepath"], node["mode"], node["include_headers"])
+        generate_html_content(
+            node["filepath"],
+            node["mode"],
+            node["include_headers"],
+            node["html_baseurl"],
+        )
     )
 
 
@@ -29,7 +34,9 @@ def depart_chemiscope_html(self, node):
     pass
 
 
-def generate_html_content(filepath, mode="default", include_headers=True):
+def generate_html_content(
+    filepath, mode="default", include_headers=True, html_baseurl=""
+):
     """
     Generate HTML content for displaying a chemiscope visualization.
 
@@ -65,4 +72,5 @@ def generate_html_content(filepath, mode="default", include_headers=True):
         html_template.replace("{{div_id}}", div_id)
         .replace("{{filepath}}", filepath)
         .replace("{{mode}}", mode)
+        .replace("{{html_baseurl}}", html_baseurl)
     )

--- a/python/chemiscope/sphinx/static/html/chemiscope-sphinx.html
+++ b/python/chemiscope/sphinx/static/html/chemiscope-sphinx.html
@@ -3,11 +3,11 @@
 <script src="https://cdnjs.cloudflare.com/ajax/libs/pako/2.0.4/pako.min.js"></script>
 
 <!-- JS scripts -->
-<script src="/_static/js/chemiscope.min.js"></script>
-<script src="/_static/js/chemiscope-sphinx.js"></script>
+<script src="{{html_baseurl}}_static/js/chemiscope.min.js"></script>
+<script src="{{html_baseurl}}_static/js/chemiscope-sphinx.js"></script>
 
 <!-- CSS styles -->
-<link rel="stylesheet" href="/_static/css/chemiscope-sphinx.css" type="text/css" />
+<link rel="stylesheet" href="{{html_baseurl}}_static/css/chemiscope-sphinx.css" type="text/css" />
 <!-- end headers -->
 
 <!-- Warning Display -->
@@ -19,7 +19,7 @@
 
 <!-- Loading Spinner -->
 <div id="{{div_id}}-loading" class="chemiscope-sphinx-spinner">
-    <img src="/_static/loading-icon.svg" alt="Loading icon" />
+    <img src="{{html_baseurl}}_static/loading-icon.svg" alt="Loading icon" />
 </div>
 
 <!-- Chemiscope Visualization -->


### PR DESCRIPTION
Added `html_baseurl` to the `conf.py` but it is relevant only for the website ! In the website there is one more folder `doc` but if we run it locally there is no additional folder.

Here is the script  to check how it will work on the website:
```
tox -e docs
rm -rf tmp && mkdir tmp/
cp -r docs/build/html tmp/doc/
cd tmp 
python -m http.server
```