### PR TITLE
Fix the location of CS header files using relative paths

### DIFF
--- a/docs/src/chemiscope-sphinx.rst
+++ b/docs/src/chemiscope-sphinx.rst
@@ -37,8 +37,8 @@ simply use the directive
     .. chemiscope:: datasets/showcase.json.gz
 
 Once compiled, this will show as this widget
-
-.. chemiscope:: datasets/showcase.json.gz
+ 
+.. chemiscope:: datasets/showcase.json.gz    
     
 The ``structure`` mode will show the structures only
 

--- a/docs/src/chemiscope-sphinx.rst
+++ b/docs/src/chemiscope-sphinx.rst
@@ -42,7 +42,7 @@ Once compiled, this will show as this widget
     
 The ``structure`` mode will show the structures only
 
-.. chemiscope:: datasets/showcase.json.gz
+.. chemiscope:: datasets/showcase.json.gz 
     :mode: structure
  
 and the ``map`` mode only the property map

--- a/docs/src/chemiscope-sphinx.rst
+++ b/docs/src/chemiscope-sphinx.rst
@@ -38,7 +38,7 @@ simply use the directive
 
 Once compiled, this will show as this widget
  
-.. chemiscope:: datasets/showcase.json.gz    
+.. chemiscope:: datasets/showcase.json.gz
     
 The ``structure`` mode will show the structures only
 

--- a/docs/src/manual/index.rst
+++ b/docs/src/manual/index.rst
@@ -27,5 +27,3 @@ extension, which can be used to explore a dataset directly inside a jupyter note
     python
     jupyter
     sharing
-    
-.. chemiscope:: ../datasets/showcase.json.gz       

--- a/docs/src/manual/index.rst
+++ b/docs/src/manual/index.rst
@@ -27,3 +27,5 @@ extension, which can be used to explore a dataset directly inside a jupyter note
     python
     jupyter
     sharing
+    
+.. chemiscope:: ../datasets/showcase.json.gz       

--- a/python/chemiscope/sphinx/directive.py
+++ b/python/chemiscope/sphinx/directive.py
@@ -1,4 +1,5 @@
 import os
+import uuid
 
 from docutils.parsers.rst import Directive
 
@@ -43,7 +44,8 @@ class ChemiscopeDirective(Directive):
             rst_file_path = source_path + dataset_rel_path
 
             # Copy dataset to the docs/build/html/_datasets folder
-            filename = os.path.basename(rst_file_path)
+            # Ensure unique file name to avoid clashes
+            filename = f"{uuid.uuid4()}-{os.path.basename(rst_file_path)}"
             build_file_path, rel_file_path = self.get_build_file_path(filename)
             copy_file(rst_file_path, build_file_path)
 
@@ -78,7 +80,15 @@ class ChemiscopeDirective(Directive):
 
         # Get destination paths
         build_file_path = os.path.join(target_dir, filename)
-        rel_file_path = os.path.relpath(build_file_path, outdir)
+
+        # Get path of output dataset relative to output HTML
+        env = self.state.document.settings.env  #
+        builder = env.app.builder
+        html_file_path = builder.get_outfilename(env.docname)
+        html_file_dir = os.path.dirname(html_file_path)
+
+        # Relative path *for the output files*
+        rel_file_path = os.path.relpath(build_file_path, html_file_dir)
 
         return build_file_path, rel_file_path
 

--- a/python/chemiscope/sphinx/nodes.py
+++ b/python/chemiscope/sphinx/nodes.py
@@ -20,8 +20,19 @@ def depart_chemiscope_latex(self, node):
 
 
 def visit_chemiscope_html(self, node):
+
+    # determines the path of the static resources
+    # relative to the output document
+    html_file_path = self.builder.get_outfilename(self.builder.current_docname)
+    html_file_dir = os.path.dirname(html_file_path)
+    # _static is the hardcoded output folder for static files
+    static_dir = os.path.join(self.builder.outdir, "_static")
+    static_path = os.path.relpath(static_dir, html_file_dir)
+
     self.body.append(
-        generate_html_content(node["filepath"], node["mode"], node["include_headers"])
+        generate_html_content(
+            node["filepath"], node["mode"], node["include_headers"], static_path
+        )
     )
 
 
@@ -29,7 +40,9 @@ def depart_chemiscope_html(self, node):
     pass
 
 
-def generate_html_content(filepath, mode="default", include_headers=True):
+def generate_html_content(
+    filepath, mode="default", include_headers=True, static_path="_static"
+):
     """
     Generate HTML content for displaying a chemiscope visualization.
 
@@ -65,4 +78,5 @@ def generate_html_content(filepath, mode="default", include_headers=True):
         html_template.replace("{{div_id}}", div_id)
         .replace("{{filepath}}", filepath)
         .replace("{{mode}}", mode)
+        .replace("{{static_path}}", static_path)
     )

--- a/python/chemiscope/sphinx/nodes.py
+++ b/python/chemiscope/sphinx/nodes.py
@@ -73,7 +73,7 @@ def generate_html_content(
             flags=re.DOTALL,
         )
 
-    # Replace html placeholders with actual values
+    # Replace html placeholders  with actual values
     return (
         html_template.replace("{{div_id}}", div_id)
         .replace("{{filepath}}", filepath)

--- a/python/chemiscope/sphinx/static/html/chemiscope-sphinx.html
+++ b/python/chemiscope/sphinx/static/html/chemiscope-sphinx.html
@@ -3,11 +3,11 @@
 <script src="https://cdnjs.cloudflare.com/ajax/libs/pako/2.0.4/pako.min.js"></script>
 
 <!-- JS scripts -->
-<script src="/_static/js/chemiscope.min.js"></script>
-<script src="/_static/js/chemiscope-sphinx.js"></script>
+<script src="{{static_path}}/js/chemiscope.min.js"></script>
+<script src="{{static_path}}/js/chemiscope-sphinx.js"></script>
 
 <!-- CSS styles -->
-<link rel="stylesheet" href="/_static/css/chemiscope-sphinx.css" type="text/css" />
+<link rel="stylesheet" href="{{static_path}}/css/chemiscope-sphinx.css" type="text/css" />
 <!-- end headers -->
 
 <!-- Warning Display -->
@@ -19,7 +19,7 @@
 
 <!-- Loading Spinner -->
 <div id="{{div_id}}-loading" class="chemiscope-sphinx-spinner">
-    <img src="/_static/loading-icon.svg" alt="Loading icon" />
+    <img src="{{static_path}}/loading-icon.svg" alt="Loading icon" />
 </div>
 
 <!-- Chemiscope Visualization -->


### PR DESCRIPTION
Determines relative path of `_static` to find the chemiscope headers