### PR TITLE
Fix calling a chemiscope widget once

### DIFF
--- a/python/chemiscope/sphinx/scraper.py
+++ b/python/chemiscope/sphinx/scraper.py
@@ -18,6 +18,9 @@ class ChemiscopeScraper:
         # Create an iterator to generate the file name
         self.iterator = FilePathIterator()
 
+        # Process the widgets once by storing their `id()` here
+        self.seen = set()
+
     def __repr__(self):
         return "ChemiscopeScraper"
 
@@ -40,7 +43,9 @@ class ChemiscopeScraper:
         widget = block_vars.get("example_globals", {}).get("___")
         mode = self.get_widget_mode(widget)
 
-        if mode is not None:
+        if (id(widget)) not in self.seen and mode is not None:
+            self.seen.add(id(widget))
+
             # Get the target directory to save the dataset next to the .rst files
             src_file = block_vars.get("target_file")  # Python file
             rst_dataset_dir = os.path.join(os.path.dirname(src_file), "_datasets")


### PR DESCRIPTION
Fix bug: code after `chemiscope.show` still calls the widget (as the widget variable is present in the `block_vars`). Example:

![image](https://github.com/lab-cosmo/chemiscope/assets/71195115/c36c345d-04a6-40c3-9e10-86c542e62668)
