### PR TITLE
Fix appling map settings x and y properties

### DIFF
--- a/src/map/map.ts
+++ b/src/map/map.ts
@@ -666,18 +666,33 @@ export class PropertiesMap {
         if (this._options.hasColors()) {
             // setup initial color range (must do before setting up events)
             const determineColorRange = (optionMin: number, optionMax: number) => {
-                // By default, range values are set to zeros
-                if (optionMin !== 0 || optionMax !== 0) {
+                const minProvided = !isNaN(optionMin);
+                const maxProvided = !isNaN(optionMax);
+
+                const getMinMaxFromValues = () => {
+                    const values = this._colors(0)[0] as number[];
+                    return arrayMaxMin(values);
+                };
+
+                if (minProvided && maxProvided) {
                     if (optionMin <= optionMax) {
                         return { min: optionMin, max: optionMax };
                     }
                     sendWarning(
                         `The inserted min and max values in color are such that min > max! The default values will be used.`
                     );
+                } else if (minProvided) {
+                    // Calculate max value from values
+                    const { max } = getMinMaxFromValues();
+                    return { min: optionMin, max: max };
+                } else if (maxProvided) {
+                    // Calculate min value from values
+                    const { min } = getMinMaxFromValues();
+                    return { min: min, max: optionMax };
                 }
-                // calculate default range
-                const values = this._colors(0)[0] as number[];
-                return arrayMaxMin(values);
+
+                // Calculate default range
+                return getMinMaxFromValues();
             };
             const { min, max } = determineColorRange(
                 this._options.color.min.value,

--- a/src/map/map.ts
+++ b/src/map/map.ts
@@ -666,7 +666,7 @@ export class PropertiesMap {
         if (this._options.hasColors()) {
             // setup initial color range (must do before setting up events)
             const determineColorRange = (optionMin: number, optionMax: number) => {
-                const [min, max] = this.getAxisRange(optionMin, optionMax, 'map.color');
+                const [min, max] = this._getAxisRange(optionMin, optionMax, 'map.color');
                 const minProvided = min !== undefined;
                 const maxProvided = max !== undefined;
 
@@ -1048,17 +1048,17 @@ export class PropertiesMap {
         layout.coloraxis.showscale = this._options.hasColors();
 
         // Set ranges for the axes
-        layout.xaxis.range = this.getAxisRange(
+        layout.xaxis.range = this._getAxisRange(
             this._options.x.min.value,
             this._options.x.max.value,
             'map.x'
         );
-        layout.yaxis.range = this.getAxisRange(
+        layout.yaxis.range = this._getAxisRange(
             this._options.y.min.value,
             this._options.y.max.value,
             'map.y'
         );
-        layout.zaxis.range = this.getAxisRange(
+        layout.zaxis.range = this._getAxisRange(
             this._options.z.min.value,
             this._options.z.max.value,
             'map.z'
@@ -1133,7 +1133,7 @@ export class PropertiesMap {
     }
 
     /** Validate provided min max values */
-    private getAxisRange = (
+    private _getAxisRange = (
         min: number,
         max: number,
         axisName: string

--- a/src/map/map.ts
+++ b/src/map/map.ts
@@ -1132,7 +1132,7 @@ export class PropertiesMap {
         this._plot.addEventListener('wheel', () => {});
     }
 
-    /** Validate provided min max values */
+    /** Validate min/max options provided by the user. We use `NaN` internally to mark missing values, which are then transformed into undefined by this function */
     private _getAxisRange = (
         min: number,
         max: number,

--- a/src/map/map.ts
+++ b/src/map/map.ts
@@ -81,13 +81,13 @@ const DEFAULT_LAYOUT = {
     },
     showlegend: true,
     xaxis: {
-        range: undefined,
+        range: undefined as undefined | number[],
         title: '',
         type: 'linear',
         zeroline: false,
     },
     yaxis: {
-        range: undefined,
+        range: undefined as undefined | number[],
         title: '',
         type: 'linear',
         zeroline: false,
@@ -1017,6 +1017,11 @@ export class PropertiesMap {
         layout.coloraxis.colorbar.title.text = this._colorTitle();
         layout.coloraxis.colorbar.len = this._colorbarLen();
         layout.coloraxis.showscale = this._options.hasColors();
+
+        // Set ranges for the axes
+        const setAxisRange = (min: number, max: number) => (min !== 0 && max !== 0 ? [min, max] : undefined);
+        layout.xaxis.range = setAxisRange(this._options.x.min.value, this._options.x.max.value);
+        layout.yaxis.range = setAxisRange(this._options.y.min.value, this._options.y.max.value);
 
         // Create an empty plot and fill it below
         Plotly.newPlot(

--- a/src/map/map.ts
+++ b/src/map/map.ts
@@ -1019,7 +1019,9 @@ export class PropertiesMap {
         layout.coloraxis.showscale = this._options.hasColors();
 
         // Set ranges for the axes
-        const setAxisRange = (min: number, max: number) => (min !== 0 && max !== 0 ? [min, max] : undefined);
+        const setAxisRange = (min: number, max: number) => {
+            return min !== 0 && max !== 0 ? [min, max] : undefined;
+        };
         layout.xaxis.range = setAxisRange(this._options.x.min.value, this._options.x.max.value);
         layout.yaxis.range = setAxisRange(this._options.y.min.value, this._options.y.max.value);
 

--- a/src/map/map.ts
+++ b/src/map/map.ts
@@ -92,6 +92,12 @@ const DEFAULT_LAYOUT = {
         type: 'linear',
         zeroline: false,
     },
+    zaxis: {
+        range: undefined as undefined | number[],
+        title: '',
+        type: 'linear',
+        zeroline: false,
+    },
 };
 
 const DEFAULT_CONFIG = {
@@ -659,9 +665,20 @@ export class PropertiesMap {
         // ======= color axis settings
         if (this._options.hasColors()) {
             // setup initial color range (must do before setting up events)
-            const values = this._colors(0)[0] as number[];
-            const { min, max } = arrayMaxMin(values);
+            const determineColorRange = (optionMin: number, optionMax: number) => {
+                // range is provided in settings by user
+                if (optionMin !== 0 && optionMax !== 0) {
+                    return { min: optionMin, max: optionMax };
+                }
 
+                // calculate default range
+                const values = this._colors(0)[0] as number[];
+                return arrayMaxMin(values);
+            };
+            const { min, max } = determineColorRange(
+                this._options.color.min.value,
+                this._options.color.max.value
+            );
             this._options.color.min.value = min;
             this._options.color.max.value = max;
             this._setScaleStep([min, max], 'color');
@@ -1024,6 +1041,7 @@ export class PropertiesMap {
         };
         layout.xaxis.range = setAxisRange(this._options.x.min.value, this._options.x.max.value);
         layout.yaxis.range = setAxisRange(this._options.y.min.value, this._options.y.max.value);
+        layout.zaxis.range = setAxisRange(this._options.z.min.value, this._options.z.max.value);
 
         // Create an empty plot and fill it below
         Plotly.newPlot(

--- a/src/map/map.ts
+++ b/src/map/map.ts
@@ -666,11 +666,15 @@ export class PropertiesMap {
         if (this._options.hasColors()) {
             // setup initial color range (must do before setting up events)
             const determineColorRange = (optionMin: number, optionMax: number) => {
-                // range is provided in settings by user
-                if (optionMin !== 0 && optionMax !== 0) {
-                    return { min: optionMin, max: optionMax };
+                // By default, range values are set to zeros
+                if (optionMin !== 0 || optionMax !== 0) {
+                    if (optionMin <= optionMax) {
+                        return { min: optionMin, max: optionMax };
+                    }
+                    sendWarning(
+                        `The inserted min and max values in color are such that min > max! The default values will be used.`
+                    );
                 }
-
                 // calculate default range
                 const values = this._colors(0)[0] as number[];
                 return arrayMaxMin(values);
@@ -1037,7 +1041,17 @@ export class PropertiesMap {
 
         // Set ranges for the axes
         const setAxisRange = (min: number, max: number) => {
-            return min !== 0 && max !== 0 ? [min, max] : undefined;
+            // At least one range value is specified. By default, zeros are set
+            if (min !== 0 || max !== 0) {
+                if (min <= max) {
+                    return [min, max];
+                }
+                sendWarning(
+                    'The inserted min and max values in axis are such that min > max! The default values will be used.'
+                );
+            }
+            // The values will be set to range in the afterplot once the plot is created
+            return undefined;
         };
         layout.xaxis.range = setAxisRange(this._options.x.min.value, this._options.x.max.value);
         layout.yaxis.range = setAxisRange(this._options.y.min.value, this._options.y.max.value);

--- a/src/map/map.ts
+++ b/src/map/map.ts
@@ -681,14 +681,13 @@ export class PropertiesMap {
                     sendWarning(
                         `The inserted min and max values in color are such that min > max! The default values will be used.`
                     );
-                } else if (minProvided) {
-                    // Calculate max value from values
-                    const { max } = getMinMaxFromValues();
-                    return { min: optionMin, max: max };
-                } else if (maxProvided) {
-                    // Calculate min value from values
-                    const { min } = getMinMaxFromValues();
-                    return { min: min, max: optionMax };
+                } else if (minProvided || maxProvided) {
+                    // Calculate min/max value from values
+                    const { min, max } = getMinMaxFromValues();
+                    return {
+                        min: minProvided ? optionMin : min,
+                        max: maxProvided ? optionMax : max,
+                    };
                 }
 
                 // Calculate default range

--- a/src/map/options.ts
+++ b/src/map/options.ts
@@ -119,8 +119,8 @@ export class MapOptions extends OptionsGroup {
         this.color = {
             mode: new HTMLOption('string', 'linear'),
             property: new HTMLOption('string', ''),
-            min: new HTMLOption('number', 0),
-            max: new HTMLOption('number', 0),
+            min: new HTMLOption('number', NaN),
+            max: new HTMLOption('number', NaN),
         };
         this.color.property.validate = optionValidator(propertiesName.concat(['']), 'color');
         this.color.mode.validate = optionValidator(['linear', 'log', 'sqrt', 'inverse'], 'mode');

--- a/src/map/options.ts
+++ b/src/map/options.ts
@@ -39,8 +39,8 @@ export class AxisOptions extends OptionsGroup {
     constructor(validProperties: string[]) {
         assert(validProperties.length > 0);
         super();
-        this.max = new HTMLOption('number', 0);
-        this.min = new HTMLOption('number', 0);
+        this.max = new HTMLOption('number', NaN);
+        this.min = new HTMLOption('number', NaN);
         this.property = new HTMLOption('string', validProperties[0]);
         this.scale = new HTMLOption('string', 'linear');
 


### PR DESCRIPTION
Fixed bug: apply setting of min and max values for x and y properties of `map` :

```
settings = {
  'map': {
    'x': {
      'property': 'PCA1',
      "min": 42,    // to be applied
      "max": 180,   // to be applied
    },
    'y': {
      'property': 'PCA2',
      "min": 46,    // to be applied
      "max": 170,   // to be applied
    }
  }
}
```