### PR TITLE
One-liner change to fix a cornercase visualization error

### DIFF
--- a/src/structure/viewer.ts
+++ b/src/structure/viewer.ts
@@ -1610,6 +1610,8 @@ export class MoleculeViewer {
                 model: this._viewer.createModelFrom(selection),
                 center: center,
             };
+            // initialize with main style
+            this._highlighted.model.setStyle({}, this._mainStyle());
         }
     }
 


### PR DESCRIPTION
You can barely see it here, but if you open a viewer with environments, disable the environments and hide the bonds, you'll see a wireframe visualization of the atoms within the selected center. 
![image](https://github.com/lab-cosmo/chemiscope/assets/1118823/2b8d0498-c853-4101-96d8-0e9ca0e8bd26)

This fixes the problem by initializing the style of the center upon creation.