### PR TITLE
Disable "more options" button in structure options by default

### DIFF
--- a/src/structure/viewer.ts
+++ b/src/structure/viewer.ts
@@ -269,6 +269,9 @@ export class MoleculeViewer {
         this._colorMoreOptions =
             this._options.getModalElement<HTMLButtonElement>('atom-color-more-options');
 
+        // Disable as by default color property is element, so no color bar available
+        this._colorMoreOptions.disabled = true;
+
         this._connectOptions();
         this._trajectoryOptions = this._options.getModalElement('trajectory-settings-group');
 


### PR DESCRIPTION
Bug reproduction steps:
1. Open `Chemical Shieldings` in the examples in chemiscope.org
2. Open settings in one of the grid cells
3. Click on "more options" button near color
4. Click on "reset min/max" button
-> exception

![image](https://github.com/user-attachments/assets/a1e5cefc-a62c-4d1e-bb93-a0bca03e6fe8)

The proposed fix is to disable "more options" initially as color property is `element` by default => no color bar is available