### PR TITLE
Fix exporting and importing of invalid values

### DIFF
--- a/src/options.ts
+++ b/src/options.ts
@@ -331,15 +331,18 @@ export abstract class OptionsGroup {
             assert(keys.length >= 1);
             const value = option.value;
 
-            let root = settings as any;
-            for (const key of keys.slice(0, keys.length - 1)) {
-                if (!(key in root)) {
-                    root[key] = {};
+            // Save property value if valid
+            if (value !== undefined || value !== null || !Number.isNaN(value)) {
+                let root = settings as any;
+                for (const key of keys.slice(0, keys.length - 1)) {
+                    if (!(key in root)) {
+                        root[key] = {};
+                    }
+                    root = root[key];
                 }
-                root = root[key];
+                const lastKey = keys[keys.length - 1];
+                root[lastKey] = value;
             }
-            const lastKey = keys[keys.length - 1];
-            root[lastKey] = value;
         });
         /* eslint-enable */
         return settings;
@@ -371,7 +374,15 @@ export abstract class OptionsGroup {
             const lastKey = keys[keys.length - 1];
 
             if (lastKey in root) {
-                option.value = root[lastKey];
+                const value = root[lastKey];
+
+                // send warning if the value is invalid and omit applying it
+                if (value === undefined || value === null || Number.isNaN(value)) {
+                    sendWarning(`ignored setting '${lastKey}' with invalid value '${value}'`);
+                    return;
+                }
+
+                option.value = value;
 
                 // remove used keys from the settings to be able to warn on
                 // unused keys


### PR DESCRIPTION
Issue to be fixed with this PR: 
1) Export of settings with NaN values.
If display mode is changed and z-axes is not selected, we export NaN to JSON as z.min and z.max are not defined; hence it breaks once someone wants to import this dataset to the chemiscope. Now we don't include such values to the exported settings.

2) Import of settings with NaN or null values. It raises an exception currently in chemiscope.org, now we send a warning about an invalid value and omit it.
