### PR TITLE
Make explore optional

### DIFF
--- a/python/chemiscope/explore.py
+++ b/python/chemiscope/explore.py
@@ -1,4 +1,5 @@
 import os
+
 from .jupyter import show
 
 
@@ -103,7 +104,7 @@ def explore(frames, featurize=None, properties=None, mode="default"):
 
     # Use default featurizer
     else:
-        X_reduced = soap_pca(frames)
+        X_reduced = soap_pca_featurize(frames)
 
     # Add dimensionality reduction results to properties
     properties["features"] = X_reduced

--- a/python/chemiscope/explore.py
+++ b/python/chemiscope/explore.py
@@ -1,15 +1,4 @@
 import os
-
-# Check if dependencies were installed
-try:
-    from dscribe.descriptors import SOAP
-    from sklearn.decomposition import PCA
-except ImportError as e:
-    raise ImportError(
-        f"Required package not found: {str(e)}. Please install dependency "
-        + "using 'pip install chemiscope[explore]'."
-    )
-
 from .jupyter import show
 
 
@@ -73,7 +62,7 @@ def explore(frames, featurize=None, properties=None, mode="default"):
 
 
         # Define a function for dimensionality reduction
-        def soap_kpca(frames):
+        def soap_kpca_featurize(frames):
             # Compute descriptors
             soap = dscribe.descriptors.SOAP(
                 species=["C"],
@@ -92,7 +81,7 @@ def explore(frames, featurize=None, properties=None, mode="default"):
 
 
         # 2) Example with a custom featurizer function
-        chemiscope.explore(frames, featurize=soap_kpca)
+        chemiscope.explore(frames, featurize=soap_kpca_featurize)
 
     For more examples, see the related `documentation <chemiscope-explore_>`_.
 
@@ -123,15 +112,26 @@ def explore(frames, featurize=None, properties=None, mode="default"):
     return show(frames=frames, properties=properties, mode=mode)
 
 
-def soap_pca(frames):
+def soap_pca_featurize(frames):
     """
     Computes SOAP features for a given set of atomic structures and performs
-    dimensionality reduction using PCA.
+    dimensionality reduction using PCA. Custom featurize functions should
+    have the same signature.
 
     Note:
     - The SOAP descriptor parameters are pre-defined.
     - We use all available CPU cores for parallel computation of SOAP descriptors.
     """
+
+    # Check if dependencies were installed
+    try:
+        from dscribe.descriptors import SOAP
+        from sklearn.decomposition import PCA
+    except ImportError as e:
+        raise ImportError(
+            f"Required package not found: {str(e)}. Please install dependency "
+            + "using 'pip install chemiscope[explore]'."
+        )
     # Get global species
     species = set()
     for frame in frames:

--- a/python/examples/6-explore.py
+++ b/python/examples/6-explore.py
@@ -103,12 +103,12 @@ from sklearn.decomposition import KernelPCA  # noqa
 
 # %%
 #
-# Define the function ``soap_kpca`` which takes one argument (``frames``). This argument
+# Define the function ``soap_kpca_featurize`` which takes one argument (``frames``). This argument
 # contains the structures provided to :py:func:`chemiscope.explore` and is internally
 # passed to the ``featurize`` function.
 
 
-def soap_kpca(frames):
+def soap_kpca_featurize(frames):
     # Initialise soap calculator. The detailed explanation of the provided
     # hyperparameters can be checked in the documentation of the library (``dscribe``).
     soap = SOAP(
@@ -138,7 +138,7 @@ def soap_kpca(frames):
 #
 # Provide the created function to :py:func:`chemiscope.explore`.
 
-cs = chemiscope.explore(frames, featurize=soap_kpca)
+cs = chemiscope.explore(frames, featurize=soap_kpca_featurize)
 
 # %%
 #
@@ -146,7 +146,7 @@ cs = chemiscope.explore(frames, featurize=soap_kpca)
 # energy from the frames using :py:func:`chemiscope.extract_properties`.
 
 properties = chemiscope.extract_properties(frames, only=["energy"])
-cs = chemiscope.explore(frames, featurize=soap_kpca, properties=properties)
+cs = chemiscope.explore(frames, featurize=soap_kpca_featurize, properties=properties)
 
 # %%
 #

--- a/python/examples/6-explore.py
+++ b/python/examples/6-explore.py
@@ -103,8 +103,9 @@ from sklearn.decomposition import KernelPCA  # noqa
 
 # %%
 #
-# Define the function ``soap_kpca_featurize`` which takes one argument (``frames``). This argument
-# contains the structures provided to :py:func:`chemiscope.explore` and is internally
+# Define the function ``soap_kpca_featurize`` which takes one argument
+# (``frames``). This argument contains the structures provided to
+# :py:func:`chemiscope.explore` and is internally
 # passed to the ``featurize`` function.
 
 


### PR DESCRIPTION
Moved imports into the default featurizer, so that one does not have to install the [explore] dependencies unless it's actually used. Also improving a bit the `explore` functionality.