### PR TITLE
Use of environments in explore

### DIFF
--- a/python/chemiscope/explore.py
+++ b/python/chemiscope/explore.py
@@ -111,6 +111,10 @@ def explore(frames, featurize=None, properties=None, environments=None, mode="de
 
     # Pick frames and properties related to the environments if provided
     if environments is not None:
+        # Sort environments by structure id and atom id
+        environments = sorted(environments, key=lambda x: (x[0], x[1]))
+
+        # Check structure indexes
         unique_structures = list({env[0] for env in environments})
         if any(index >= len(frames) for index in unique_structures):
             raise IndexError(
@@ -118,9 +122,6 @@ def explore(frames, featurize=None, properties=None, environments=None, mode="de
             )
 
         if len(unique_structures) != len(frames):
-            # Sort environments by structure id and atom id
-            environments = sorted(environments, key=lambda x: (x[0], x[1]))
-
             # Pick frames corresponding to the environments
             frames = [frames[index] for index in unique_structures]
 

--- a/python/chemiscope/explore.py
+++ b/python/chemiscope/explore.py
@@ -18,6 +18,9 @@ def explore(frames, featurize=None, properties=None, environments=None, mode="de
     cores for parallelization. PCA reduces the dimensionality to two components by
     default.
 
+    If `environments` is provided, frames and properties are filtered to include only
+    those related to the environments.
+
     :param list frames: list of frames
 
     :param callable featurize: optional. Function to compute features and perform

--- a/python/chemiscope/explore.py
+++ b/python/chemiscope/explore.py
@@ -204,7 +204,7 @@ def soap_pca_featurize(frames, environments=None):
 
 def _extract_environment_indices(envs):
     """
-    Extract environment indices per structure
+    Convert from chemiscope's environements to DScribe's centers selection 
 
     :param: list envs: each element is a list of [env_index, atom_index, cutoff]
     """

--- a/python/chemiscope/explore.py
+++ b/python/chemiscope/explore.py
@@ -69,7 +69,7 @@ def explore(frames, featurize=None, properties=None, environments=None, mode="de
 
 
         # Define a function for dimensionality reduction
-        def soap_kpca_featurize(frames):
+        def soap_kpca_featurize(frames, _environments):
             # Compute descriptors
             soap = dscribe.descriptors.SOAP(
                 species=["C"],
@@ -175,6 +175,12 @@ def soap_pca_featurize(frames, centers=None):
 
 
 def _pick_env_frames(envs, frames):
+    """
+    Get environment indices par structures and pick corresponding frames
+
+    :param: list envs: each element is a list of [env_index, atom_index, cutoff]
+    :param: list frames: list of frames
+    """
     grouped_envs = {}
     picked_frames = []
     for [env_index, atom_index, _cutoff] in envs:

--- a/python/chemiscope/explore.py
+++ b/python/chemiscope/explore.py
@@ -18,9 +18,6 @@ def explore(frames, featurize=None, properties=None, environments=None, mode="de
     cores for parallelization. PCA reduces the dimensionality to two components by
     default.
 
-    If `environments` is provided, frames and properties are filtered to include only
-    those related to the environments.
-
     :param list frames: list of frames
 
     :param callable featurize: optional. Function to compute features and perform

--- a/python/chemiscope/explore.py
+++ b/python/chemiscope/explore.py
@@ -162,7 +162,7 @@ def soap_pca_featurize(frames, environments=None):
             )
 
         if len(unique_structures) != len(frames):
-            # Pick frames corresponding to the environments
+            # only include frames that are present in the user-provided environments
             frames = [frames[index] for index in unique_structures]
 
     # Get global species

--- a/python/chemiscope/explore.py
+++ b/python/chemiscope/explore.py
@@ -118,7 +118,7 @@ def explore(frames, featurize=None, properties=None, environments=None, mode="de
         unique_structures = list({env[0] for env in environments})
         if any(index >= len(frames) for index in unique_structures):
             raise IndexError(
-                "Some or more indices are greater than the length of the frames"
+                "Some structure indices in 'environments' are larger than the number of frames"
             )
 
         if len(unique_structures) != len(frames):

--- a/python/chemiscope/explore.py
+++ b/python/chemiscope/explore.py
@@ -33,7 +33,7 @@ def explore(frames, featurize=None, properties=None, environments=None, mode="de
     :param environments: optional. List of environments (described as
         ``(structure id, center id, cutoff)``) to include when extracting the
         atomic properties. Can be extracted from frames with
-        :py:func:`all_atomic_environments` (or :py:func:`librascal_atomic_environments`)
+        :py:func:`all_atomic_environments`.
         or manually defined.
 
     :param str mode: optional. Visualization mode for the chemiscope widget. Can be one

--- a/python/chemiscope/explore.py
+++ b/python/chemiscope/explore.py
@@ -69,7 +69,9 @@ def explore(frames, featurize=None, properties=None, environments=None, mode="de
 
 
         # Define a function for dimensionality reduction
-        def soap_kpca_featurize(frames, _environments):
+        def soap_kpca_featurize(frames, environments):
+            if environments is not None:
+                raise ValueError("'environments' are not supported")
             # Compute descriptors
             soap = dscribe.descriptors.SOAP(
                 species=["C"],

--- a/python/chemiscope/explore.py
+++ b/python/chemiscope/explore.py
@@ -71,7 +71,7 @@ def explore(frames, featurize=None, properties=None, environments=None, mode="de
         # Define a function for dimensionality reduction
         def soap_kpca_featurize(frames, environments):
             if environments is not None:
-                raise ValueError("'environments' are not supported")
+                raise ValueError("'environments' are not supported by this featurizer")
             # Compute descriptors
             soap = dscribe.descriptors.SOAP(
                 species=["C"],

--- a/python/examples/6-explore.py
+++ b/python/examples/6-explore.py
@@ -92,9 +92,8 @@ chemiscope.explore(frames)
 # this example. Alternatively, the environments can be extracted from the frames using
 # the function :py:func:`all_atomic_environments`.
 #
-# In the following example, we also demonstrate a way to provide properties for
-# visualization. The frames and properties related to the indexes in the
-# ``environments`` will be extracted.
+# We also demonstrate a way to provide properties for visualization. The frames and
+# properties related to the indexes in the ``environments`` will be extracted.
 
 properties = chemiscope.extract_properties(frames, only=["energy"])
 environments = [(0, 0, 3.5), (1, 0, 3.5), (2, 1, 3.5)]

--- a/python/examples/6-explore.py
+++ b/python/examples/6-explore.py
@@ -126,7 +126,7 @@ from sklearn.decomposition import KernelPCA  # noqa
 
 def soap_kpca_featurize(frames, environments):
     if environments is not None:
-        raise ValueError("'environments' are not supported")
+        raise ValueError("'environments' are not supported by this featurizer")
     # Initialise soap calculator. The detailed explanation of the provided
     # hyperparameters can be checked in the documentation of the library (``dscribe``).
     soap = SOAP(

--- a/python/examples/6-explore.py
+++ b/python/examples/6-explore.py
@@ -89,12 +89,16 @@ chemiscope.explore(frames)
 # Besides this, it is possible to run the dimentionality reduction algorithm and display
 # specific atom-centered environments. They can be manually defined by specifying a list
 # of tuples in the format ``[index of structure, index of atom, cutoff]``, as shown in
-# this example.
+# this example. Alternatively, the environments can be extracted from the frames using
+# the function :py:func:`all_atomic_environments`.
 #
-# Alternatively, the environments can be extracted from the frames using the function
-# :py:func:`all_atomic_environments` or :py:func:`librascal_atomic_environments`.
+# In the following example, we also demonstrate a way to provide properties for
+# visualization. The frames and properties related to the indexes in the
+# ``environments`` will be extracted.
 
-chemiscope.explore(frames, environments=[(0, 0, 3.5), (1, 0, 3.5), (2, 1, 3.5)])
+properties = chemiscope.extract_properties(frames, only=["energy"])
+environments = [(0, 0, 3.5), (1, 0, 3.5), (2, 1, 3.5)]
+chemiscope.explore(frames, environments=environments, properties=properties)
 
 # %%
 #

--- a/python/examples/6-explore.py
+++ b/python/examples/6-explore.py
@@ -125,7 +125,9 @@ from sklearn.decomposition import KernelPCA  # noqa
 # if they were provided to the :py:func:`chemiscope.explore`.
 
 
-def soap_kpca_featurize(frames, _environments):
+def soap_kpca_featurize(frames, environments):
+    if environments is not None:
+        raise ValueError("'environments' are not supported")
     # Initialise soap calculator. The detailed explanation of the provided
     # hyperparameters can be checked in the documentation of the library (``dscribe``).
     soap = SOAP(

--- a/python/examples/6-explore.py
+++ b/python/examples/6-explore.py
@@ -88,7 +88,7 @@ chemiscope.explore(frames)
 #
 # Besides this, it is possible to run the dimentionality reduction algorithm and display
 # specific atom-centered environments. They can be manually defined by specifying a list
-# of tuples in the format ``[index of structure, index of atom, cutoff]``, as shown in
+# of tuples in the format ``(structure_index, atom_index, cutoff)``, as shown in
 # this example. Alternatively, the environments can be extracted from the frames using
 # the function :py:func:`all_atomic_environments`.
 #

--- a/python/examples/6-explore.py
+++ b/python/examples/6-explore.py
@@ -69,10 +69,7 @@ frames = ase.io.read("data/explore_c-gap-20u.xyz", ":")
 #
 # Provide the frames to the :py:func:`chemiscope.explore`. It will generate a Chemiscope
 # interactive widget with the reduced dimensionality of data.
-envs = [(0, 0, 3.5),
- (1, 1, 3.5),
- (2, 2, 3.5)]
-chemiscope.explore(frames, environments=envs)
+chemiscope.explore(frames)
 
 # %%
 #
@@ -86,6 +83,18 @@ chemiscope.explore(frames, environments=envs)
 # for dimensionality reduction. The resulting components are then added to the
 # properties to be used in visualization.
 
+
+# %%
+#
+# Besides this, it is possible to run the dimentionality reduction algorithm and display
+# specific atom-centered environments. They can be manually defined by specifying a list
+# of tuples in the format ``[index of structure, index of atom, cutoff]``, as shown in
+# this example.
+#
+# Alternatively, the environments can be extracted from the frames using the function
+# :py:func:`all_atomic_environments` or :py:func:`librascal_atomic_environments`.
+
+chemiscope.explore(frames, environments=[(0, 0, 3.5), (1, 0, 3.5), (2, 1, 3.5)])
 
 # %%
 #
@@ -105,10 +114,11 @@ from sklearn.decomposition import KernelPCA  # noqa
 
 # %%
 #
-# Define the function ``soap_kpca_featurize`` which takes one argument
-# (``frames``). This argument contains the structures provided to
-# :py:func:`chemiscope.explore` and is internally
-# passed to the ``featurize`` function.
+# Define the function ``soap_kpca_featurize`` which takes two arguments
+# (``frames``, which contains the structures provided to
+# :py:func:`chemiscope.explore` and internally passed to the ``featurize`` function;
+# ``environments``,  optional aurgument with the atom-centered environments,
+# if they were provided to the :py:func:`chemiscope.explore`.
 
 
 def soap_kpca_featurize(frames, _environments):

--- a/python/examples/6-explore.py
+++ b/python/examples/6-explore.py
@@ -69,8 +69,10 @@ frames = ase.io.read("data/explore_c-gap-20u.xyz", ":")
 #
 # Provide the frames to the :py:func:`chemiscope.explore`. It will generate a Chemiscope
 # interactive widget with the reduced dimensionality of data.
-
-chemiscope.explore(frames)
+envs = [(0, 0, 3.5),
+ (1, 1, 3.5),
+ (2, 2, 3.5)]
+chemiscope.explore(frames, environments=envs)
 
 # %%
 #
@@ -109,7 +111,7 @@ from sklearn.decomposition import KernelPCA  # noqa
 # passed to the ``featurize`` function.
 
 
-def soap_kpca_featurize(frames):
+def soap_kpca_featurize(frames, _environments):
     # Initialise soap calculator. The detailed explanation of the provided
     # hyperparameters can be checked in the documentation of the library (``dscribe``).
     soap = SOAP(

--- a/python/examples/7-explore-advanced.py
+++ b/python/examples/7-explore-advanced.py
@@ -143,7 +143,9 @@ m3cd_frames = ase.io.read("data/explore_m3cd.xyz", ":")
 # different mace calculator.
 
 
-def mace_mp0_tsne(frames, _environments):
+def mace_mp0_tsne(frames, environments):
+    if environments is not None:
+        raise ValueError("'environments' are not supported")
     # Initialise a mace-mp0 calculator
     descriptor_opt = {"model": "small", "device": "cpu", "default_dtype": "float64"}
     calculator = mace_mp(**descriptor_opt)

--- a/python/examples/7-explore-advanced.py
+++ b/python/examples/7-explore-advanced.py
@@ -65,7 +65,7 @@ qm9_frames = ase.io.read("data/explore_qm9.xyz", ":")
 
 def mace_off_tsne(frames, environments):
     if environments is not None:
-        raise ValueError("'environments' are not supported")
+        raise ValueError("'environments' are not supported by this featurizer")
 
     # At first, we initialize a mace_off calculator:
     descriptor_opt = {"model": "small", "device": "cpu", "default_dtype": "float64"}

--- a/python/examples/7-explore-advanced.py
+++ b/python/examples/7-explore-advanced.py
@@ -62,7 +62,7 @@ qm9_frames = ase.io.read("data/explore_qm9.xyz", ":")
 # return the reduced data.
 
 
-def mace_off_tsne(frames):
+def mace_off_tsne(frames, _environments):
     # At first, we initialize a mace_off calculator:
     descriptor_opt = {"model": "small", "device": "cpu", "default_dtype": "float64"}
     calculator = mace_off(**descriptor_opt)
@@ -141,7 +141,7 @@ m3cd_frames = ase.io.read("data/explore_m3cd.xyz", ":")
 # different mace calculator.
 
 
-def mace_mp0_tsne(frames):
+def mace_mp0_tsne(frames, _environments):
     # Initialise a mace-mp0 calculator
     descriptor_opt = {"model": "small", "device": "cpu", "default_dtype": "float64"}
     calculator = mace_mp(**descriptor_opt)

--- a/python/examples/7-explore-advanced.py
+++ b/python/examples/7-explore-advanced.py
@@ -147,7 +147,7 @@ m3cd_frames = ase.io.read("data/explore_m3cd.xyz", ":")
 
 def mace_mp0_tsne(frames, environments):
     if environments is not None:
-        raise ValueError("'environments' are not supported")
+        raise ValueError("'environments' are not supported by this featurizer")
 
     # Initialise a mace-mp0 calculator
     descriptor_opt = {"model": "small", "device": "cpu", "default_dtype": "float64"}

--- a/python/examples/7-explore-advanced.py
+++ b/python/examples/7-explore-advanced.py
@@ -188,16 +188,16 @@ chemiscope.show_input("data/mace-mp-tsne-m3cd.json.gz")
 
 # %%
 #
-# Example usage of environments with SOAP and t-SNE
-# +++++++++++++++++++++++++++++++++++++++++++++++++++++
+# Example Usage of SOAP and t-SNE with environments
+# +++++++++++++++++++++++++++++++++++++++++++++++++
 #
-# In this example, we demonstrate how to use the SOAP to compute atomic
-# descriptors and then visualize them using t-SNE.
+# This example demonstrates how to compute descriptors using the SOAP and t-SNE with
+# ``environments`` parameter specifying which atoms in the frames are used for
+# calculating the descriptors.
 #
-# Provide a created function and environments to :py:func:`chemiscope.explore`.
-# Use the defined ``soap_tnse_with_environments``` function to compute t-SNE embeddings
-# and explore them with a widget.
-#
+# We are defining a custom featurizer that takes frames and environments. Note, that the
+# frames corresponding to the ``environments`` will already be picked internally once
+# :py:func:`chemiscope.explore` is executed.
 
 
 def soap_tnse_with_environments(frames, environments):
@@ -241,7 +241,13 @@ def soap_tnse_with_environments(frames, environments):
     return reducer.fit_transform(feats)
 
 
-cs = chemiscope.explore(
+# %%
+#
+# Provide a created function and environments to :py:func:`chemiscope.explore`. The
+# environments are manually defined following the format ``[index of structure, index
+# of atom, cutoff]``.
+
+chemiscope.explore(
     frames=m3cd_frames,
     featurize=soap_tnse_with_environments,
     environments=[(1, 2, 3.5), (2, 0, 3.5)],

--- a/python/examples/7-explore-advanced.py
+++ b/python/examples/7-explore-advanced.py
@@ -62,7 +62,9 @@ qm9_frames = ase.io.read("data/explore_qm9.xyz", ":")
 # return the reduced data.
 
 
-def mace_off_tsne(frames, _environments):
+def mace_off_tsne(frames, environments):
+    if environments is not None:
+        raise ValueError("'environments' are not supported")
     # At first, we initialize a mace_off calculator:
     descriptor_opt = {"model": "small", "device": "cpu", "default_dtype": "float64"}
     calculator = mace_off(**descriptor_opt)

--- a/python/examples/7-explore-advanced.py
+++ b/python/examples/7-explore-advanced.py
@@ -200,7 +200,7 @@ chemiscope.show_input("data/mace-mp-tsne-m3cd.json.gz")
 
 def soap_tnse_with_environments(frames, environments):
     if environments is None:
-        raise ValueError("'environments' supposed to be provided")
+        raise ValueError("'environments' must be provided")
 
     grouped_envs = {}
     unique_structures = set()

--- a/python/examples/7-explore-advanced.py
+++ b/python/examples/7-explore-advanced.py
@@ -213,7 +213,7 @@ def soap_tnse_with_environments(frames, environments):
         unique_structures.add(env_index)
     centers = list(grouped_envs.values())
 
-    # Pick the frames corresponding to the structure indices
+    # only include frames that are present in the environments
     if len(unique_structures) != len(frames):
         frames = [frames[index] for index in sorted(unique_structures)]
 

--- a/python/examples/7-explore-advanced.py
+++ b/python/examples/7-explore-advanced.py
@@ -188,29 +188,34 @@ chemiscope.show_input("data/mace-mp-tsne-m3cd.json.gz")
 
 # %%
 #
-# Example Usage of SOAP and t-SNE with environments
+# Example with SOAP, t-SNE and environments
 # +++++++++++++++++++++++++++++++++++++++++++++++++
 #
 # This example demonstrates how to compute descriptors using the SOAP and t-SNE with
 # ``environments`` parameter specifying which atoms in the frames are used for
 # calculating the descriptors.
 #
-# We are defining a custom featurizer that takes frames and environments. Note, that the
-# frames corresponding to the ``environments`` will already be picked internally once
-# :py:func:`chemiscope.explore` is executed.
+# We are defining a custom featurizer that takes frames and environments.
 
 
 def soap_tnse_with_environments(frames, environments):
     if environments is None:
         raise ValueError("'environments' supposed to be provided")
 
-    # Get center indices from environments
     grouped_envs = {}
+    unique_structures = set()
+
+    # Get atom-centered indices from environments
     for [env_index, atom_index, _cutoff] in environments:
         if env_index not in grouped_envs:
             grouped_envs[env_index] = []
         grouped_envs[env_index].append(atom_index)
+        unique_structures.add(env_index)
     centers = list(grouped_envs.values())
+
+    # Pick the frames corresponding to the structure indices
+    if len(unique_structures) != len(frames):
+        frames = [frames[index] for index in sorted(unique_structures)]
 
     # Get global species
     species = set()


### PR DESCRIPTION
Added a `environments` parameter in the `chemiscope.explore` and added an example of its usage