### PR TITLE
Better error messages and target selection logic

### DIFF
--- a/src/dataset.ts
+++ b/src/dataset.ts
@@ -302,7 +302,7 @@ export function getTarget(dataset: Dataset): DisplayTarget {
     // Target is specified in settings
     if (target !== undefined) {
         if (target === 'atom' && dataset.environments === undefined) {
-            throw new Error('To use "atom" target, "settings.properties" should be provided');
+            throw new Error('To use "atom" target, a list of environments should be provided');
         }
         if (getTargetProps(target).length < 2) {
             throw new Error(

--- a/src/dataset.ts
+++ b/src/dataset.ts
@@ -304,15 +304,11 @@ export function getTarget(dataset: Dataset): DisplayTarget {
         if (target === 'atom' && dataset.environments === undefined) {
             throw new Error('To use "atom" target, a list of environments should be provided');
         }
-        if (getTargetProps(target).length < 2) {
-            throw new Error(
-                `The provided target (${target}) cannot be used. Make sure there are at least two corresponding properties ('settings.properties').`
-            );
-        }
         return target;
     }
+    // Default to atom properties if there are environments AND atomic properties
     const atomProperties = getTargetProps('atom');
-    return dataset.environments !== undefined && atomProperties.length > 1 ? 'atom' : 'structure';
+    return dataset.environments !== undefined && atomProperties.length > 0 ? 'atom' : 'structure';
 }
 
 function checkMetadata(o: JsObject) {

--- a/src/map/options.ts
+++ b/src/map/options.ts
@@ -99,7 +99,11 @@ export class MapOptions extends OptionsGroup {
 
         // Setup axes
         const propertiesName = Object.keys(properties);
-        assert(propertiesName.length >= 2);
+        if (propertiesName.length < 2) {
+            throw new Error(
+                'Cannot show a map because the dataset contains fewer than two properties.'
+            );
+        }
         this.x = new AxisOptions(propertiesName);
         this.y = new AxisOptions(propertiesName);
         // For z and color '' is a valid value


### PR DESCRIPTION
This PR is to solve two bugs:
1. the error message when one requires atom target without specifying environments
2. the error logic when one requires a target explicitly and there aren't >=2 properties - I think we shouldn't do the check here because one could be asking for a structure-only visualization (this is how I found the problem). 

(2) can be fixed by NOT checking number of properties (which is what I propose, that is checked later on when displaying the map, if the map is requested) or by also passing the viz mode to getTarget (which would be a pain and IMO unnecessary). 