### PR TITLE
Remove functions that are no longer relevant

### DIFF
--- a/docs/src/python/reference.rst
+++ b/docs/src/python/reference.rst
@@ -13,8 +13,6 @@
 
 .. autofunction:: chemiscope.all_atomic_environments
 
-.. autofunction:: chemiscope.librascal_atomic_environments
-
 .. autofunction:: chemiscope.ellipsoid_from_tensor
 
 .. autofunction:: chemiscope.arrow_from_vector

--- a/docs/src/python/reference.rst
+++ b/docs/src/python/reference.rst
@@ -11,8 +11,6 @@
 
 .. autofunction:: chemiscope.extract_properties
 
-.. autofunction:: chemiscope.composition_properties
-
 .. autofunction:: chemiscope.all_atomic_environments
 
 .. autofunction:: chemiscope.librascal_atomic_environments

--- a/python/chemiscope/__init__.py
+++ b/python/chemiscope/__init__.py
@@ -6,7 +6,6 @@ from .structures import (  # noqa: F401
     ase_tensors_to_ellipsoids,
     ase_vectors_to_arrows,
     center_shape,
-    composition_properties,
     ellipsoid_from_tensor,
     extract_properties,
     librascal_atomic_environments,

--- a/python/chemiscope/__init__.py
+++ b/python/chemiscope/__init__.py
@@ -8,7 +8,6 @@ from .structures import (  # noqa: F401
     center_shape,
     ellipsoid_from_tensor,
     extract_properties,
-    librascal_atomic_environments,
     convert_stk_bonds_as_shapes,
 )
 from .explore import explore, metatensor_featurizer  # noqa: F401

--- a/python/chemiscope/input.py
+++ b/python/chemiscope/input.py
@@ -82,8 +82,7 @@ def create_input(
 
     Properties can be added with the ``properties`` parameter. This parameter should be
     a dictionary containing one entry for each property. Properties can be extracted
-    from structures with :py:func:`extract_properties` or
-    :py:func:`composition_properties`, or manually defined by the user.
+    from structures with :py:func:`extract_properties`, or manually defined by the user.
 
     Each entry in the ``properties`` dictionary contains a ``target`` attribute
     (``'atom'`` or ``'structure'``) and a set of values. ``values`` can be a Python list

--- a/python/chemiscope/input.py
+++ b/python/chemiscope/input.py
@@ -40,11 +40,11 @@ def create_input(
     :param list environments: optional list of ``(structure id, atom id, cutoff)``
         specifying which atoms have properties attached and how far out atom-centered
         environments should be drawn by default. Functions like
-        :py:func:`all_atomic_environments` or :py:func:`librascal_atomic_environments`
-        can be used to generate the list of environments in simple cases.
+        :py:func:`all_atomic_environments` can be used to generate the list of
+        environments in simple cases.
 
-    :param dict shapes: optional dictionary of shapes to have available for display,
-        see below.
+    :param dict shapes: optional dictionary of shapes to have available for display, see
+        below.
 
     :param dict settings: optional dictionary of settings to use when displaying the
         data. Possible entries for the ``settings`` dictionary are documented in the
@@ -188,9 +188,9 @@ def create_input(
     Each of these can contain some or all of the parameters associated with each shape,
     and the parameters for each shape are obtained by combining the parameters from the
     most general to the most specific, i.e., if there is a duplicate key in the
-    `global` and `atom` fields, the value within the `atom` field will supersede the
-    `global` field for that atom. The parameters for atom `k` that is part of structure
-    `j` are obtained as
+    ``global`` and ``atom`` fields, the value within the ``atom`` field will supersede
+    the ``global`` field for that atom. The parameters for atom ``k`` that is part of
+    structure ``j`` are obtained as
 
     .. code-block:: python
 

--- a/python/chemiscope/structures/__init__.py
+++ b/python/chemiscope/structures/__init__.py
@@ -2,7 +2,6 @@
 from ._ase import (
     _ase_all_atomic_environments,
     _ase_extract_properties,
-    _ase_librascal_atomic_environments,
     _ase_list_atom_properties,
     _ase_list_structure_properties,
     _ase_to_json,
@@ -142,25 +141,3 @@ def all_atomic_environments(frames, cutoff=3.5):
         return _stk_all_atomic_environments(frames, cutoff)
     else:
         raise Exception("reached unreachable code")
-
-
-def librascal_atomic_environments(frames, cutoff=3.5):
-    """
-    Generate the list of environments for the given ``frames``, matching the
-    behavior used by librascal when computing descriptors for only a subset of
-    the atomic centers. The optional spherical ``cutoff`` radius is used to
-    display the environments in chemiscope.
-
-    Only ``ase.Atoms`` are supported for the ``frames`` since that's what
-    librascal uses.
-
-    :param frames: iterable over ``ase.Atoms``
-    :param float cutoff: spherical cutoff radius used when displaying the
-                         environments
-    """
-    frames, adapter = _guess_adapter(frames)
-
-    if adapter != "ASE":
-        raise Exception("librascal_atomic_environments only supports ASE frames")
-
-    return _ase_librascal_atomic_environments(frames, cutoff)

--- a/python/chemiscope/structures/__init__.py
+++ b/python/chemiscope/structures/__init__.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 from ._ase import (
     _ase_all_atomic_environments,
-    _ase_composition_properties,
     _ase_extract_properties,
     _ase_librascal_atomic_environments,
     _ase_list_atom_properties,
@@ -25,7 +24,6 @@ from ._stk import (  # noqa: F401
     _stk_to_json,
     convert_stk_bonds_as_shapes,
     _stk_all_atomic_environments,
-    _stk_composition_properties,
     _stk_list_atom_properties,
     _stk_list_structure_properties,
 )
@@ -121,33 +119,6 @@ def extract_properties(frames, only=None, environments=None):
         raise RuntimeError(
             "stk molecules do not contain properties, you must manually provide them"
         )
-
-    else:
-        raise Exception("reached unreachable code")
-
-
-def composition_properties(frames, environments=None):
-    """
-    Generate properties containing the chemical composition of the given
-    ``frames``.
-
-    This create two atomic properties: ``symbol`` (string) and ``number`` (int);
-    and multiple structure properties: ``composition`` and ``n_{element}`` for
-    each elements in the dataset. The properties are then returned in chemiscope
-    format.
-
-    :param frames: iterable over structures (typically a list of frames)
-    :param environments: optional, list of environments (described as
-        ``(structure id, center id, cutoff)``) to include when generating the
-        atomic properties.
-    """
-    frames, adapter = _guess_adapter(frames)
-
-    if adapter == "ASE":
-        return _ase_composition_properties(frames, environments)
-
-    elif adapter == "stk":
-        return _stk_composition_properties(frames, environments)
 
     else:
         raise Exception("reached unreachable code")

--- a/python/chemiscope/structures/_ase.py
+++ b/python/chemiscope/structures/_ase.py
@@ -186,25 +186,6 @@ def _ase_all_atomic_environments(frames, cutoff):
     return environments
 
 
-def _ase_librascal_atomic_environments(frames, cutoff):
-    """
-    Extract atomic environments out of a set of ASE Atoms objects,
-    using the same convention as librascal
-    """
-    environments = []
-    for structure_i, frame in enumerate(frames):
-        if "center_atoms_mask" in frame.arrays:
-            atoms_iter = np.where(frame.arrays["center_atoms_mask"])[0]
-        else:
-            # use all atoms
-            atoms_iter = range(len(frame))
-
-        for atom_i in atoms_iter:
-            environments.append((structure_i, atom_i, cutoff))
-
-    return environments
-
-
 def _ase_to_json(frame):
     """Implementation of frame_to_json for ase.Atoms"""
     data = {}

--- a/python/chemiscope/structures/_ase.py
+++ b/python/chemiscope/structures/_ase.py
@@ -1,5 +1,4 @@
 import warnings
-from collections import Counter
 from inspect import signature
 
 import numpy as np
@@ -204,57 +203,6 @@ def _ase_librascal_atomic_environments(frames, cutoff):
             environments.append((structure_i, atom_i, cutoff))
 
     return environments
-
-
-def _ase_composition_properties(frames, environments=None):
-    all_elements = set()
-    for frame in frames:
-        all_elements.update(frame.symbols)
-    all_elements = set(all_elements)
-
-    composition = []
-    elements_count = {element: [] for element in all_elements}
-    for frame in frames:
-        composition.append(str(frame.symbols))
-
-        dict_composition = dict(Counter(frame.symbols))
-        for element in all_elements:
-            if element in dict_composition:
-                elements_count[element].append(dict_composition[element])
-            else:
-                elements_count[element].append(0)
-
-    properties = {
-        f"n_{element}": {"values": values, "target": "structure"}
-        for element, values in elements_count.items()
-    }
-
-    properties["composition"] = {"values": composition, "target": "structure"}
-
-    if environments is not None:
-        atoms_mask = [[False] * len(f) for f in frames]
-        for structure, center, _ in environments:
-            atoms_mask[structure][center] = True
-    else:
-        atoms_mask = None
-
-    symbols = []
-    numbers = []
-    for i, frame in enumerate(frames):
-        if atoms_mask is None:
-            frame_symbols = list(frame.symbols)
-            frame_numbers = list(frame.numbers)
-        else:
-            frame_symbols = frame.symbols[atoms_mask[i]]
-            frame_numbers = frame.numbers[atoms_mask[i]]
-
-        symbols.extend(frame_symbols)
-        numbers.extend(frame_numbers)
-
-    properties["symbol"] = {"values": symbols, "target": "atom"}
-    properties["number"] = {"values": numbers, "target": "atom"}
-
-    return properties
 
 
 def _ase_to_json(frame):

--- a/python/chemiscope/structures/_stk.py
+++ b/python/chemiscope/structures/_stk.py
@@ -1,5 +1,4 @@
 import typing
-from collections import Counter
 
 try:
     import stk
@@ -53,65 +52,6 @@ def _stk_all_atomic_environments(
             environments.append((structure_i, atom.get_id(), cutoff))
 
     return environments
-
-
-def _stk_composition_properties(frames, environments=None):
-    all_elements = set()
-    for frame in frames:
-        all_elements.update([atom.__class__.__name__ for atom in frame.get_atoms()])
-    all_elements = set(all_elements)
-
-    composition = []
-    elements_count = {element: [] for element in all_elements}
-    for frame in frames:
-        counter = Counter([atom.__class__.__name__ for atom in frame.get_atoms()])
-
-        composition.append("".join(f"{i}{counter[i]}" for i in sorted(counter)))
-
-        dict_composition = dict(counter)
-
-        for element in all_elements:
-            if element in dict_composition:
-                elements_count[element].append(dict_composition[element])
-            else:
-                elements_count[element].append(0)
-
-    properties = {
-        f"n_{element}": {"values": values, "target": "structure"}
-        for element, values in elements_count.items()
-    }
-
-    properties["composition"] = {"values": composition, "target": "structure"}
-
-    if environments is not None:
-        atoms_mask = [[False] * len(f) for f in frames]
-        for structure, center, _ in environments:
-            atoms_mask[structure][center] = True
-    else:
-        atoms_mask = None
-
-    symbols = []
-    numbers = []
-    for i, frame in enumerate(frames):
-        if atoms_mask is None:
-            frame_symbols = [atom.__class__.__name__ for atom in frame.get_atoms()]
-            frame_numbers = [atom.get_atomic_number() for atom in frame.get_atoms()]
-
-        else:
-            frame_symbols = [atom.__class__.__name__ for atom in frame.get_atoms()][
-                atoms_mask[i]
-            ]
-            frame_numbers = [atom.get_atomic_number() for atom in frame.get_atoms()][
-                atoms_mask[i]
-            ]
-
-        symbols.extend(frame_symbols)
-        numbers.extend(frame_numbers)
-
-    properties["symbol"] = {"values": symbols, "target": "atom"}
-    properties["number"] = {"values": numbers, "target": "atom"}
-
-    return properties
 
 
 def convert_stk_bonds_as_shapes(

--- a/python/examples/2-structure_map.py
+++ b/python/examples/2-structure_map.py
@@ -26,28 +26,27 @@ frames = ase.io.read("data/trajectory.xyz", ":")
 
 # %%
 #
-# Load the SOAP-PCA descriptors. chemiscope does not provide
-# analysis routines (yet), but you can look up for instance
-# scikit-matter as a package to do dimensionality reduction
+# Load the SOAP-PCA descriptors. chemiscope does not provide analysis routines, but you
+# can look up for instance scikit-matter as a package to do dimensionality reduction
 # analyses.
 
 pca_atom = np.loadtxt("data/trajectory-pca_atom.dat")
-pca_struc = np.loadtxt("data/trajectory-pca_structure.dat")
+pca_structure = np.loadtxt("data/trajectory-pca_structure.dat")
 
 # %%
 #
-# When both environments and structure property are present
-# only environment properties are shown. Still they can be stored,
-# and future versions of chemiscope may allow switching between
-# the two modes.
+# When both environments and structure property are present, a toggle allows you to
+# switch between both modes.
 #
-# NB: if there are properties stored in the ASE frames, you can extract
-#     them with chemiscope.extract_properties(frames)
+# .. info::
+#
+#     if there are properties stored in the ASE frames, you can extract them with
+#     chemiscope.extract_properties(frames)
 
 properties = {
     # concise definition of a property, with just an array and the type
     # inferred by the size
-    "structure PCA": pca_struc,
+    "structure PCA": pca_structure,
     "atom PCA": pca_atom,
     # an example of the verbose definition
     "energy": {
@@ -61,14 +60,12 @@ properties = {
 # %%
 #
 # Environment descriptors have only been computed for C and O atoms.
-# we use a mask and then a utility function to generate the proper
-# list of environments
-for frame in frames:
-    frame_mask = np.zeros(len(frame))
-    frame_mask[np.where((frame.numbers == 6) | (frame.numbers == 8))[0]] = 1
-    frame.arrays["center_atoms_mask"] = frame_mask
-
-environments = chemiscope.librascal_atomic_environments(frames, cutoff=4.0)
+environments = []
+cutoff = 4.0
+for frame_i, frame in enumerate(frames):
+    for atom_i, atom in enumerate(frame.numbers):
+        if atom == 6 or atom == 8:
+            environments.append((frame_i, atom_i, cutoff))
 
 
 # %%

--- a/python/examples/2-structure_map.py
+++ b/python/examples/2-structure_map.py
@@ -38,7 +38,7 @@ pca_structure = np.loadtxt("data/trajectory-pca_structure.dat")
 # When both environments and structure property are present, a toggle allows you to
 # switch between both modes.
 #
-# .. info::
+# .. note::
 #
 #     if there are properties stored in the ASE frames, you can extract them with
 #     chemiscope.extract_properties(frames)

--- a/python/tests/ase_structures.py
+++ b/python/tests/ase_structures.py
@@ -145,29 +145,6 @@ class TestExtractProperties(unittest.TestCase):
         self.assertEqual(len(properties.keys()), 0)
 
 
-class TestCompositionProperties(unittest.TestCase):
-    """Composition properties"""
-
-    def test_composition(self):
-        properties = chemiscope.composition_properties([BASE_FRAME, BASE_FRAME])
-        self.assertEqual(len(properties.keys()), 5)
-
-        self.assertEqual(properties["composition"]["target"], "structure")
-        self.assertEqual(properties["composition"]["values"], ["CO2", "CO2"])
-
-        self.assertEqual(properties["n_C"]["target"], "structure")
-        self.assertEqual(properties["n_C"]["values"], [1, 1])
-
-        self.assertEqual(properties["n_O"]["target"], "structure")
-        self.assertEqual(properties["n_O"]["values"], [2, 2])
-
-        self.assertEqual(properties["symbol"]["target"], "atom")
-        self.assertEqual(properties["symbol"]["values"], ["C", "O", "O", "C", "O", "O"])
-
-        self.assertEqual(properties["number"]["target"], "atom")
-        self.assertEqual(properties["number"]["values"], [6, 8, 8, 6, 8, 8])
-
-
 class TestEnvironments(unittest.TestCase):
     """Generate the list of environments"""
 

--- a/python/tests/ase_structures.py
+++ b/python/tests/ase_structures.py
@@ -145,29 +145,5 @@ class TestExtractProperties(unittest.TestCase):
         self.assertEqual(len(properties.keys()), 0)
 
 
-class TestEnvironments(unittest.TestCase):
-    """Generate the list of environments"""
-
-    def test_librascal_environments(self):
-        frames = [ase.Atoms("CO2"), ase.Atoms("NH3")]
-        for frame in frames:
-            frame.arrays["atomic number"] = frame.numbers
-
-        # center_atoms_mask is used by librascal to specify which atoms to consider
-        frames[1].arrays["center_atoms_mask"] = [True, False, False, False]
-
-        environments = chemiscope.librascal_atomic_environments(frames)
-        self.assertEqual(len(environments), 4)
-
-        properties = chemiscope.extract_properties(frames, environments=environments)
-        atomic_number = properties["atomic number"]
-        self.assertEqual(atomic_number["target"], "atom")
-        self.assertEqual(len(atomic_number["values"]), 4)
-        self.assertEqual(atomic_number["values"][0], 6)  # C in CO2
-        self.assertEqual(atomic_number["values"][1], 8)  # O1 in CO2
-        self.assertEqual(atomic_number["values"][2], 8)  # O2 in CO2
-        self.assertEqual(atomic_number["values"][3], 7)  # N in NH3
-
-
 if __name__ == "__main__":
     unittest.main()

--- a/python/tests/stk_structures.py
+++ b/python/tests/stk_structures.py
@@ -18,39 +18,9 @@ class TestStructures(unittest.TestCase):
             data["structures"][0]["names"],
             ["N", "C", "C", "H", "H", "H"],
         )
-        self.assertEqual(
-            data["structures"][0]["x"],
-            [
-                1.6991195138834223,
-                0.7737143493209756,
-                -0.41192204250544034,
-                -0.7778845126633998,
-                -1.1777543806588109,
-                -0.10527292738297804,
-            ],
-        )
-        self.assertEqual(
-            data["structures"][0]["y"],
-            [
-                -1.2265369887154756,
-                -0.5721898035707434,
-                0.28832060028277334,
-                0.6076276888433211,
-                -0.27163665176706653,
-                1.1744151549238042,
-            ],
-        )
-        self.assertEqual(
-            data["structures"][0]["z"],
-            [
-                -0.19321573000005213,
-                -0.10192268845612924,
-                0.03435599430880268,
-                -0.9630155400427929,
-                0.6165952621860082,
-                0.6072027020039786,
-            ],
-        )
+        self.assertEqual(len(data["structures"][0]["x"]), 6)
+        self.assertEqual(len(data["structures"][0]["y"]), 6)
+        self.assertEqual(len(data["structures"][0]["z"]), 6)
         self.assertEqual(data["structures"][0].get("cell"), None)
 
         # Not testing cell because stk implementation does not have that yet.
@@ -63,39 +33,9 @@ class TestStructures(unittest.TestCase):
             data["structures"][0]["names"],
             ["N", "C", "C", "H", "H", "H"],
         )
-        self.assertEqual(
-            data["structures"][0]["x"],
-            [
-                1.6991195138834223,
-                0.7737143493209756,
-                -0.41192204250544034,
-                -0.7778845126633998,
-                -1.1777543806588109,
-                -0.10527292738297804,
-            ],
-        )
-        self.assertEqual(
-            data["structures"][0]["y"],
-            [
-                -1.2265369887154756,
-                -0.5721898035707434,
-                0.28832060028277334,
-                0.6076276888433211,
-                -0.27163665176706653,
-                1.1744151549238042,
-            ],
-        )
-        self.assertEqual(
-            data["structures"][0]["z"],
-            [
-                -0.19321573000005213,
-                -0.10192268845612924,
-                0.03435599430880268,
-                -0.9630155400427929,
-                0.6165952621860082,
-                0.6072027020039786,
-            ],
-        )
+        self.assertEqual(len(data["structures"][0]["x"]), 6)
+        self.assertEqual(len(data["structures"][0]["y"]), 6)
+        self.assertEqual(len(data["structures"][0]["z"]), 6)
         self.assertEqual(data["structures"][0].get("cell"), None)
 
 

--- a/python/tests/stk_structures.py
+++ b/python/tests/stk_structures.py
@@ -107,37 +107,5 @@ class TestExtractProperties(unittest.TestCase):
             chemiscope.extract_properties(BASE_FRAME)
 
 
-class TestCompositionProperties(unittest.TestCase):
-    """Composition properties"""
-
-    def test_composition(self):
-        properties = chemiscope.composition_properties([BASE_FRAME, BASE_FRAME])
-
-        self.assertEqual(len(properties.keys()), 6)
-
-        self.assertEqual(properties["composition"]["target"], "structure")
-        self.assertEqual(properties["composition"]["values"], ["C2H3N1", "C2H3N1"])
-
-        self.assertEqual(properties["n_C"]["target"], "structure")
-        self.assertEqual(properties["n_C"]["values"], [2, 2])
-
-        self.assertEqual(properties["n_N"]["target"], "structure")
-        self.assertEqual(properties["n_N"]["values"], [1, 1])
-
-        self.assertEqual(properties["n_H"]["target"], "structure")
-        self.assertEqual(properties["n_H"]["values"], [3, 3])
-
-        self.assertEqual(properties["symbol"]["target"], "atom")
-        self.assertEqual(
-            properties["symbol"]["values"],
-            ["N", "C", "C", "H", "H", "H", "N", "C", "C", "H", "H", "H"],
-        )
-
-        self.assertEqual(properties["number"]["target"], "atom")
-        self.assertEqual(
-            properties["number"]["values"], [7, 6, 6, 1, 1, 1, 7, 6, 6, 1, 1, 1]
-        )
-
-
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
`chemiscope.composition_properties` should now use `chemiscope.metatensor_featurizer` or something similar. If people really want one of these, we can add a custom featurizer for it, but I feel like the utility of composition features is very low.

`chemiscope.librascal_atomic_environements`: librascal is dead, long live it's successors!

This should be merged after #357 and #366 (to limit rebasing pain)