### PR TITLE
Added robots.txt to avoid crawling redirect URLs

### DIFF
--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -43,6 +43,7 @@ templates_path = ["_templates"]
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
 exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
+html_extra_path = ["robots.txt"]
 
 examples_dirs = os.path.join(ROOT, "python", "examples")
 sphinx_gallery_conf = {

--- a/docs/src/robots.txt
+++ b/docs/src/robots.txt
@@ -1,0 +1,5 @@
+User-agent: *
+
+Disallow: /docs/_sources/
+Disallow: /*load=
+


### PR DESCRIPTION
Google keeps crawling `?load=url` links which I fear might eventually become problematic (there are 100ks, apparently). Hoping that this helps keep only actual pages to be indexed. 