### PR TITLE
Allow file-like objects as input to chemiscope.show_input

### DIFF
--- a/python/chemiscope/jupyter.py
+++ b/python/chemiscope/jupyter.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 import gzip
-import io
 import json
 import warnings
+from pathlib import Path
 
 import ipywidgets
 from traitlets import Bool, Dict, Int, Unicode
@@ -116,9 +116,9 @@ def show_input(path, mode="default", warning_timeout=10000):
     Loads and shows the chemiscope widget in ``path``.
     If ``path`` ends with ``.gz``, the file is loaded as a gzip compressed
     JSON string.
-    If ``path`` is a file-like object, it is read as a JSON string.
+    If ``path`` is a file-like object, it is read as JSON input.
 
-    :param str | io.IOBase path: load the chemiscope widget from path.
+    :param str | Path | io.IOBase path: load the chemiscope widget from path.
 
     :param str mode: widget mode, either ``default``, ``structure`` or ``map``.
     :param float warning_timeout: timeout (in ms) for warnings. Set to a
@@ -153,19 +153,20 @@ def show_input(path, mode="default", warning_timeout=10000):
     elif mode == "map":
         widget_class = MapWidget
 
-    if isinstance(path, io.IOBase):
-        dict_input = json.load(path)
-    elif path.endswith(".gz"):
-        with gzip.open(path, "rt") as f:
-            dict_input = json.load(f)
-    elif path.endswith(".json"):
-        with open(path, "rt") as f:
-            dict_input = json.load(f)
+    if isinstance(path, (str, Path)):
+        if path.endswith(".gz"):
+            with gzip.open(path, "rt") as f:
+                dict_input = json.load(f)
+        elif path.endswith(".json"):
+            with open(path, "rt") as f:
+                dict_input = json.load(f)
+        else:
+            raise ValueError(
+                "invalid file format in chemiscope.load,\
+                            expected .json or .json.gz"
+            )
     else:
-        raise ValueError(
-            "invalid file format in chemiscope.load,\
-                         expected .json or .json.gz"
-        )
+        dict_input = json.load(path)
 
     try:
         meta = dict_input["meta"]

--- a/python/chemiscope/jupyter.py
+++ b/python/chemiscope/jupyter.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import gzip
+import io
 import json
 import warnings
 
@@ -115,8 +116,9 @@ def show_input(path, mode="default", warning_timeout=10000):
     Loads and shows the chemiscope widget in ``path``.
     If ``path`` ends with ``.gz``, the file is loaded as a gzip compressed
     JSON string.
+    If ``path`` is a file-like object, it is read as a JSON string.
 
-    :param str path: load the chemiscope widget from path.
+    :param str | io.IOBase path: load the chemiscope widget from path.
 
     :param str mode: widget mode, either ``default``, ``structure`` or ``map``.
     :param float warning_timeout: timeout (in ms) for warnings. Set to a
@@ -127,6 +129,11 @@ def show_input(path, mode="default", warning_timeout=10000):
         import chemiscope
 
         widget = chemiscope.show_input("dataset.json")
+
+        # or
+
+        with open("dataset.json", "r") as f:
+            widget = chemiscope.show_input(f)
 
     ..
     """
@@ -146,7 +153,9 @@ def show_input(path, mode="default", warning_timeout=10000):
     elif mode == "map":
         widget_class = MapWidget
 
-    if path.endswith(".gz"):
+    if isinstance(path, io.IOBase):
+        dict_input = json.load(path)
+    elif path.endswith(".gz"):
         with gzip.open(path, "rt") as f:
             dict_input = json.load(f)
     elif path.endswith(".json"):

--- a/python/chemiscope/jupyter.py
+++ b/python/chemiscope/jupyter.py
@@ -113,16 +113,17 @@ class MapWidget(ChemiscopeWidgetBase):
 
 def show_input(path, mode="default", warning_timeout=10000):
     """
-    Loads and shows the chemiscope widget in ``path``.
-    If ``path`` ends with ``.gz``, the file is loaded as a gzip compressed
-    JSON string.
+    Loads and shows the chemiscope input in ``path``.
+
+    If ``path`` ends with ``.gz``, the file is loaded as a gzip compressed JSON string.
     If ``path`` is a file-like object, it is read as JSON input.
 
-    :param str | Path | io.IOBase path: load the chemiscope widget from path.
+    :param str | Path | file-like path: load the chemiscope input from this path or
+        file-like object
 
     :param str mode: widget mode, either ``default``, ``structure`` or ``map``.
-    :param float warning_timeout: timeout (in ms) for warnings. Set to a
-        negative value to disable warnings, and to zero to make them persistent.
+    :param float warning_timeout: timeout (in ms) for warnings. Set to a negative value
+        to disable warnings, and to zero to make them persistent.
 
     .. code-block:: python
 
@@ -153,7 +154,10 @@ def show_input(path, mode="default", warning_timeout=10000):
     elif mode == "map":
         widget_class = MapWidget
 
-    if isinstance(path, (str, Path)):
+    if isinstance(path, Path):
+        path = str(path)
+
+    if isinstance(path, str):
         if path.endswith(".gz"):
             with gzip.open(path, "rt") as f:
                 dict_input = json.load(f)
@@ -162,8 +166,7 @@ def show_input(path, mode="default", warning_timeout=10000):
                 dict_input = json.load(f)
         else:
             raise ValueError(
-                "invalid file format in chemiscope.load,\
-                            expected .json or .json.gz"
+                "invalid file format in chemiscope.load, expected .json or .json.gz"
             )
     else:
         dict_input = json.load(path)


### PR DESCRIPTION
This is useful in combination with libraries like [fsspec](https://filesystem-spec.readthedocs.io/) which allow to fetch data files from remote resources.

See https://github.com/lab-cosmo/chemiscope/issues/407