### PR TITLE
Added a couple of missing options to the input file reference

### DIFF
--- a/docs/src/manual/input.rst
+++ b/docs/src/manual/input.rst
@@ -285,6 +285,10 @@ contains the following fields and values:
                     // in the case of `inverse` scaling, this is reversed.
                     "reverse": false | true,
                 },
+                // whether points in the map should have a thin black outline
+                "markerOutline": true | false,
+                // whether the points in the map should be linked by a thin black trace
+                "joinPoints": false | true,
             },
             // Settings related to the structure viewers grid. This is an array
             // containing the settings for each separate viewer


### PR DESCRIPTION
As the title says, we forgot to add a couple of new visualization options to the input reference in the docs