### PR TITLE
Make `structures` a positional argument again

### DIFF
--- a/python/chemiscope/jupyter.py
+++ b/python/chemiscope/jupyter.py
@@ -291,8 +291,8 @@ def show_input(path, *, mode="default", warning_timeout=10000, cache_structures=
 
 
 def show(
-    *,
     structures=None,
+    *,
     properties=None,
     metadata=None,
     environments=None,


### PR DESCRIPTION
Follow up to #468, `structures` was changed to a keyword argument and changed back for all functions, but I forgot to update `chemiscope.show`
