### PR TITLE
Allow to override visualization settings from show_input

### DIFF
--- a/python/chemiscope/jupyter.py
+++ b/python/chemiscope/jupyter.py
@@ -287,7 +287,9 @@ def show_input(
 
     if settings is not None:
         if not isinstance(settings, dict):
-            raise ValueError(f"expected 'settings' to be a dict, got {type(settings)} instead")
+            raise ValueError(
+                f"expected 'settings' to be a dict, got {type(settings)} instead"
+            )
         if "settings" not in dict_input:
             dict_input["settings"] = {}
         dict_input["settings"].update(settings)


### PR DESCRIPTION
It's handy to be able to load an existing chemiscope from jupyter while changing the visualization settings