### PR TITLE
Save scale being not saved while switching to 3d

### DIFF
--- a/src/map/map.ts
+++ b/src/map/map.ts
@@ -857,6 +857,11 @@ export class PropertiesMap {
         // Send a warning if a property contains negative values, that will be
         // discarded when using a log scale for this axis
         const negativeLogWarning = (axis: AxisOptions) => {
+            // skip if axis has no property set (e.g. z axis in 2d mode)
+            if (axis.property.value === '') {
+                return;
+            }
+
             if (
                 axis.scale.value === 'log' &&
                 arrayMaxMin(this._coordinates(axis, 0)[0] as number[])['min'] < 0 &&


### PR DESCRIPTION
fixes two small issues:
- axis scale not preserved when switching from 2d to 3d (e.g., having log scale for x and y, and then adding z axes should still remain x and y in log)
- second error got while testing:`values is not iterable`, while having z in log scale and then choosing `None` for z property