### PR TITLE
 Fix duplicate extra "reset view" button appears when switching mode in 3D

### DIFF
--- a/src/map/map.ts
+++ b/src/map/map.ts
@@ -421,7 +421,7 @@ export class PropertiesMap {
             this._connectSettings();
 
             // Re-render the plot with the new data and layout
-            return this._react(this._getTraces(), this._getLayout());
+            return this._react(this._getTraces(), this._getLayout(), this._getConfig());
         }
         return Promise.resolve();
     }


### PR DESCRIPTION
Fix of the bug: when we are in 3D and the dataset has both `atom` and `structure` modes, switch to one another causes an extra reset button to appear (eg see chemical shielding example).

<img width="676" height="190" alt="Screenshot 2026-01-30 at 11 43 54" src="https://github.com/user-attachments/assets/6ded5ced-6a01-4980-9e39-433fc3412253" />
