### PR TITLE
Fix: in sphinx gallery widget, structure panel collapses to zero height when switching target

### DIFF
--- a/python/chemiscope/sphinx/static/chemiscope-sphinx.css
+++ b/python/chemiscope/sphinx/static/chemiscope-sphinx.css
@@ -49,6 +49,7 @@
         flex-wrap: wrap;
         background: white;
         padding-bottom: 16px;
+        height: 550px;
     }
 
     .visualizer-column {
@@ -57,18 +58,37 @@
         display: flex;
         flex-direction: column;
         padding-left: 10px;
+        height: 100%;
     }
 
     .visualizer-column-right {
         flex: 1;
         position: relative;
         padding-right: 10px;
+        height: 100%;
+        display: flex;
+        flex-direction: column;
+    }
+
+    /* ensure map container fills available space and allows toggle to be visible */
+    .visualizer-column-right > div:last-child {
+        flex: 1;
+        min-height: 0;
+        display: flex;
+        flex-direction: column;
+    }
+
+    .visualizer-column-right > div:last-child > div:first-child {
+        flex: 1;
+        min-height: 0;
+        height: auto !important;
     }
 
     .visualizer-item {
         width: 100%;
         height: 100%;
         flex: 1;
+        min-height: 0;
     }
 
     .visualizer-info {


### PR DESCRIPTION
E.g. in `2-Structure-property maps` example be in 3d and then click on switch target, it gets :
<img width="763" height="542" alt="Screenshot 2026-01-30 at 13 11 01" src="https://github.com/user-attachments/assets/74a7be7f-8066-4c53-b806-e8470e153c87" />
