### PR TITLE
Prioritize selected points when doing LOD to avoid artifacts

### DIFF
--- a/src/map/lod.ts
+++ b/src/map/lod.ts
@@ -89,9 +89,11 @@ export function computeScreenSpaceLOD(
         const idx = ui + vi * binsX;
         // Foreground ids (priorityMask[id] === true) get the high bit cleared,
         // background ids get it set, so any foreground id always beats any
-        // background id competing for the same bin.
+        // background id competing for the same bin. The `>>> 0` keeps the
+        // result an unsigned 32-bit value so it compares correctly against
+        // bestHash, which is read from a Uint32Array.
         const baseH = Math.imul(id, 2654435761) >>> 1;
-        const h = priorityMask && !priorityMask[id] ? baseH | 0x80000000 : baseH;
+        const h = priorityMask && !priorityMask[id] ? (baseH | 0x80000000) >>> 0 : baseH;
         if (h < bestHash[idx]) {
             bestHash[idx] = h;
             grid[idx] = id;
@@ -220,9 +222,11 @@ export function computeLODIndices(
 
         // Foreground ids (priorityMask[id] === true) get the high bit cleared,
         // background ids get it set, so any foreground id always beats any
-        // background id competing for the same bin.
+        // background id competing for the same bin. The `>>> 0` keeps the
+        // result an unsigned 32-bit value so it compares correctly against
+        // bestHash, which is read from a Uint32Array.
         const baseH = Math.imul(id, 2654435761) >>> 1;
-        const h = priorityMask && !priorityMask[id] ? baseH | 0x80000000 : baseH;
+        const h = priorityMask && !priorityMask[id] ? (baseH | 0x80000000) >>> 0 : baseH;
         if (h < bestHash[idx]) {
             bestHash[idx] = h;
             grid[idx] = id;

--- a/src/map/lod.ts
+++ b/src/map/lod.ts
@@ -16,6 +16,9 @@ import { CameraState, projectPoints } from '../utils/camera';
  * @param bounds Optional boundaries to clip the data
  * @param maxPoints Maximum number of points to display
  * @param aspectRatio Width/height ratio of plot area
+ * @param priorityMask Optional boolean mask: ids with mask[id] === true win their
+ *                     bin over ids with mask[id] === false (used to prefer
+ *                     foreground points when a selection filter is active).
  * @returns Array of indices to display
  */
 export function computeScreenSpaceLOD(
@@ -25,7 +28,8 @@ export function computeScreenSpaceLOD(
     camera: CameraState,
     bounds?: Bounds,
     maxPoints: number = 50000,
-    aspectRatio: number = 1.0
+    aspectRatio: number = 1.0,
+    priorityMask?: boolean[]
 ): number[] {
     if (bounds === undefined) {
         const xRange = arrayMaxMin(xValues);
@@ -83,7 +87,11 @@ export function computeScreenSpaceLOD(
         }
 
         const idx = ui + vi * binsX;
-        const h = Math.imul(id, 2654435761) >>> 0;
+        // Foreground ids (priorityMask[id] === true) get the high bit cleared,
+        // background ids get it set, so any foreground id always beats any
+        // background id competing for the same bin.
+        const baseH = Math.imul(id, 2654435761) >>> 1;
+        const h = priorityMask && !priorityMask[id] ? baseH | 0x80000000 : baseH;
         if (h < bestHash[idx]) {
             bestHash[idx] = h;
             grid[idx] = id;
@@ -109,6 +117,9 @@ export function computeScreenSpaceLOD(
  * @param zValues Array of Z coordinates (or null for 2D)
  * @param bounds Optional boundaries to clip the data
  * @param maxPoints Maximum number of points to display
+ * @param priorityMask Optional boolean mask: ids with mask[id] === true win their
+ *                     bin over ids with mask[id] === false (used to prefer
+ *                     foreground points when a selection filter is active).
  * @returns Array of indices to display
  */
 export function computeLODIndices(
@@ -116,7 +127,8 @@ export function computeLODIndices(
     yValues: number[],
     zValues: number[] | null,
     bounds?: Bounds,
-    maxPoints: number = 50000
+    maxPoints: number = 50000,
+    priorityMask?: boolean[]
 ): number[] {
     const is3D = zValues !== null;
 
@@ -206,7 +218,11 @@ export function computeLODIndices(
             idx += zi * bins * bins;
         }
 
-        const h = Math.imul(id, 2654435761) >>> 0;
+        // Foreground ids (priorityMask[id] === true) get the high bit cleared,
+        // background ids get it set, so any foreground id always beats any
+        // background id competing for the same bin.
+        const baseH = Math.imul(id, 2654435761) >>> 1;
+        const h = priorityMask && !priorityMask[id] ? baseH | 0x80000000 : baseH;
         if (h < bestHash[idx]) {
             bestHash[idx] = h;
             grid[idx] = id;

--- a/src/map/map.ts
+++ b/src/map/map.ts
@@ -1082,7 +1082,10 @@ export class PropertiesMap {
         });
 
         // ======= selection
+        // Selection changes alter the foreground/background split, which feeds
+        // into LOD prioritization, so recompute LOD before restyling.
         const updateColors = () => {
+            this._computeLOD();
             this._restyleFull();
         };
 
@@ -2286,6 +2289,28 @@ export class PropertiesMap {
         const is3D = this._is3D() && zProp !== '';
         const zValues = is3D ? this._property(zProp).values : null;
 
+        // When a selection filter is active, prefer foreground points: pass the
+        // mask as a priority signal to the LOD functions. If hide mode is on
+        // and the foreground subset fits under the threshold, skip LOD entirely
+        // for that subset so every foreground point is shown.
+        const selectMode = this._options.color.select.mode.value;
+        let priorityMask: boolean[] | undefined;
+        if (selectMode !== 'all') {
+            priorityMask = this._getSelectionMask();
+            if (selectMode.endsWith('hide')) {
+                const foreground: number[] = [];
+                for (let i = 0; i < priorityMask.length; i++) {
+                    if (priorityMask[i]) {
+                        foreground.push(i);
+                    }
+                }
+                if (foreground.length <= PropertiesMap.LOD_THRESHOLD) {
+                    this._lodIndices = foreground;
+                    return;
+                }
+            }
+        }
+
         const lodSet = new Set<number>();
 
         // Coarse pass
@@ -2297,7 +2322,8 @@ export class PropertiesMap {
             yValues,
             zValues,
             undefined,
-            PropertiesMap.LOD_THRESHOLD / 10
+            PropertiesMap.LOD_THRESHOLD / 10,
+            priorityMask
         );
 
         for (const id of lodIndices) {
@@ -2315,9 +2341,17 @@ export class PropertiesMap {
                       this._options.camera.value,
                       bounds,
                       PropertiesMap.LOD_THRESHOLD / 2,
-                      this._plot.clientWidth / this._plot.clientHeight || 1.0
+                      this._plot.clientWidth / this._plot.clientHeight || 1.0,
+                      priorityMask
                   )
-                : computeLODIndices(xValues, yValues, zValues, bounds, PropertiesMap.LOD_THRESHOLD);
+                : computeLODIndices(
+                      xValues,
+                      yValues,
+                      zValues,
+                      bounds,
+                      PropertiesMap.LOD_THRESHOLD,
+                      priorityMask
+                  );
 
         for (const id of fineIndices) {
             lodSet.add(id);


### PR DESCRIPTION
When the selection is very small, most of the selected points will be dropped by LOD, creating a visual artifact when using range or class based masking.