### PR TITLE
Raise an error if a metatomic model request custom inputs 

### DIFF
--- a/python/chemiscope/explore/_metatomic.py
+++ b/python/chemiscope/explore/_metatomic.py
@@ -110,6 +110,15 @@ class metatomic_featurizer:
 
         self.device = _find_best_device(capabilities.supported_devices, device)
 
+        extra_inputs = self.model.requested_inputs(use_new_names=True)
+        if len(extra_inputs) > 0:
+            raise ValueError(
+                (
+                    "this model requires additional inputs that can not be provided by"
+                    f"chemiscope: {', '.join(extra_inputs)}"
+                )
+            )
+
     def __call__(self, structures, environments):
         systems = mta.systems_to_torch(structures)
         calculators = vesin_metatomic.neighbor_lists_for_model(

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 # https://github.com/tox-dev/tox/issues/3238
-requires = tox==4.14.0
+requires = tox >=4.39
 
 envlist =
     lint


### PR DESCRIPTION
These are not supported in chemiscope at this point.