### PR TITLE
apply ruff 0.16 formatting and pin ruff version

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -40,9 +40,7 @@ properties = {
     }
 }
 
-chemiscope.write_input(
-    "my-input.json.gz", structures=structures, properties=properties
-)
+chemiscope.write_input("my-input.json.gz", structures=structures, properties=properties)
 ```
 
 To display a chemiscope widget inside a notebook:

--- a/tox.ini
+++ b/tox.ini
@@ -42,7 +42,7 @@ commands =
 description = Lint Python code
 package = skip
 deps =
-    ruff
+    ruff==0.16.*
 
 commands =
     ruff format --diff {[testenv]lint_folders}
@@ -52,7 +52,7 @@ commands =
 description = Abuse tox to do actual formatting on all files
 package = skip
 deps =
-    ruff
+    ruff==0.16.*
 commands =
     ruff format {[testenv]lint_folders}
     ruff check --fix-only {[testenv]lint_folders}


### PR DESCRIPTION
see a failed job in CI: https://github.com/lab-cosmo/chemiscope/actions/runs/30228253301/job/89862163813?pr=590

it fails because the new version of ruff is not happy with one line in our README
i also pin `ruff==0.16.*` in the tox.ini so future ruff releases do not break CI unexpectedly